### PR TITLE
fix(deps): bump vulnerable crates to patched versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4775,7 +4775,7 @@ dependencies = [
  "sparesults",
  "spareval",
  "spargebra",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4802,7 +4802,7 @@ dependencies = [
  "json-event-parser",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4815,7 +4815,7 @@ dependencies = [
  "oxiri",
  "oxsdatatypes",
  "rand 0.8.6",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4828,7 +4828,7 @@ dependencies = [
  "oxrdf",
  "oxrdfxml",
  "oxttl",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4841,7 +4841,7 @@ dependencies = [
  "oxiri",
  "oxrdf",
  "quick-xml",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4861,7 +4861,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06fa874d87eae638daae9b4e3198864fe2cce68589f227c0b2cf5b62b1530516"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4874,7 +4874,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6533,7 +6533,7 @@ dependencies = [
  "memchr",
  "oxrdf",
  "quick-xml",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6556,7 +6556,7 @@ dependencies = [
  "sparesults",
  "spargebra",
  "sparopt",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6570,7 +6570,7 @@ dependencies = [
  "oxrdf",
  "peg",
  "rand 0.8.6",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]


### PR DESCRIPTION
fix(deps): bump vulnerable crates to patched versions

Cargo.lock bumps for outstanding Dependabot alerts.
Updated 2 crate version(s) across 1 workspace(s).

Updated:
  - [.] gix-fs -> latest (high)
  - [.] lru -> latest (low)

Skipped (Cargo.toml constraint blocks — manifest bump needed):
  - [.] rand@0.9.3 (low, GHSA-cq8v-f236-94qc)
  - [.] rand@0.10.1 (low, GHSA-cq8v-f236-94qc)
