### PR TITLE
ci: repin trufflehog off unresolvable moving-`main` SHA (standards#82)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check for secrets
-        uses: trufflesecurity/trufflehog@7ee2e0fdffec27d19ccbb8fb3dcf8a83b9d7f9e8 # main
+        uses: trufflesecurity/trufflehog@05cccb53bc9e13bc6d17997db5a6bcc3df44bf2f # v3.92.3
         with:
           path: ./
           base: ${{ github.event.pull_request.base.sha || github.event.before }}


### PR DESCRIPTION
Fixes the unresolvable trufflehog pin tracked in **standards#82**.

`trufflesecurity/trufflehog@7ee2e0fdffec27d19ccbb8fb3dcf8a83b9d7f9e8` was a SHA captured from upstream's moving `main`; upstream GC'd it so it no longer resolves. Resolution happens at **`Set up job`** (before the step), so the step's `continue-on-error` cannot help — the job goes hard-red.

Repinned to the released-tag SHA already used by the **reposystem / v3-templater canonical `quality.yml`**: `@05cccb53bc9e13bc6d17997db5a6bcc3df44bf2f # v3.92.3` (deterministic, canonical-coherent).

One-line change; YAML validated; verified from the git object store.

Refs hyperpolymath/standards#82

🤖 Generated with [Claude Code](https://claude.com/claude-code)