### PR TITLE
fix(licence): clear scaffold-placeholder leak (rebuilt clean)

### DIFF
--- a/RSR_OUTLINE.adoc
+++ b/RSR_OUTLINE.adoc
@@ -209,7 +209,7 @@ This template is part of:
 
 == License
 
-SPDX-License-Identifier: PMPL-1.0-or-later-or-later
+SPDX-License-Identifier: PMPL-1.0-or-later
 
 == Links
 

--- a/contractiles/must/Mustfile
+++ b/contractiles/must/Mustfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PLMP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Mustfile - mandatory checks
 # See: https://github.com/hyperpolymath/mustfile
 


### PR DESCRIPTION
Rebuilt from origin/main (original #12 was behind + conflicting). PLMP/PMLP + doubled -> PMPL-1.0-or-later. Diff = SPDX lines only. Refs hyperpolymath/standards LICENCE-POLICY.adoc A5.