### PR TITLE
ci: repin trufflehog off unresolvable moving-main SHA

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0  # Full history for scanning
 
       - name: TruffleHog Secret Scan
-        uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3
+        uses: trufflesecurity/trufflehog@05cccb53bc9e13bc6d17997db5a6bcc3df44bf2f # v3.92.3
         with:
           extra_args: --only-verified --fail
 


### PR DESCRIPTION
trufflesecurity/trufflehog@7ee2e0fd… (a SHA from upstream's moving `main`, since GC'd) no longer resolves -> the job hard-fails at "Set up job". Repin to released tag v3.92.3 (canonical pin used by reposystem/v3-templater quality.yml).

Refs hyperpolymath/standards#82