### PR TITLE
fix(verisim-document): tantivy 0.26 collector API — add .order_by_score()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,23 +126,7 @@ lto = true
 codegen-units = 1
 panic = "abort"
 
-# Patch Bridge mitigations — forced upgrades for transitive CVEs in tantivy 0.25.0
-# These override the versions pinned by tantivy without forking.
-#
-# RUSTSEC-2026-0041: lz4_flex 0.11.5 — memory leak on decompression (CVSS 8.2 HIGH)
-#   Chain: tantivy 0.25.0 → lz4_flex 0.11.5
-#   Fix: 0.11.6 adds proper offset validation. Semver-compatible, safe to patch.
-#
-# RUSTSEC-2026-0002: lru 0.12.5 — IterMut Stacked Borrows violation (unsound)
-#   Chain: tantivy 0.25.0 → lru 0.12.5
-#   Fix: 0.12.6+ not available in 0.12.x line. Patching to 0.12.5 is NOT possible.
-#   The fix is in 0.16.3 which is semver-incompatible with tantivy's lru ^0.12 pin.
-#   Status: UNMITIGABLE without tantivy upgrade. tantivy 0.25.0 is latest.
-#   Risk: Low in practice — VeriSimDB uses #![forbid(unsafe_code)] in verisim-document,
-#   and the IterMut violation requires specific Miri-detectable UB, not exploitable
-#   in normal execution. Accepted risk until tantivy 0.26.
-#
-# NOTE: quinn-proto 0.11.14 (Dependabot alert — build-time only, NOT runtime)
+# NOTE: quinn-proto (Dependabot alert — build-time only, NOT runtime)
 # Chain: burn 0.20 → cubecl-cpu → tracel-llvm-bundler (build dep) → reqwest 0.12 → quinn → quinn-proto
 # This is a build-time dependency for LLVM artifact download, not in any production code path.
 # Waiting for burn 0.21 stable release. reqwest bumped to 0.13 for direct deps.

--- a/rust-core/verisim-document/src/lib.rs
+++ b/rust-core/verisim-document/src/lib.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
+// Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 //! VeriSim Document Modality
 //!
 //! Full-text search via Tantivy.
@@ -275,7 +276,7 @@ impl DocumentStore for TantivyDocumentStore {
             QueryParser::for_index(&self.index, vec![self.schema.title, self.schema.body]);
 
         let parsed_query = query_parser.parse_query(query)?;
-        let top_docs = searcher.search(&parsed_query, &TopDocs::with_limit(limit))?;
+        let top_docs = searcher.search(&parsed_query, &TopDocs::with_limit(limit).order_by_score())?;
 
         // Create snippet generator for body field
         let snippet_generator =

--- a/rust-core/verisim-document/src/lib.rs
+++ b/rust-core/verisim-document/src/lib.rs
@@ -276,7 +276,8 @@ impl DocumentStore for TantivyDocumentStore {
             QueryParser::for_index(&self.index, vec![self.schema.title, self.schema.body]);
 
         let parsed_query = query_parser.parse_query(query)?;
-        let top_docs = searcher.search(&parsed_query, &TopDocs::with_limit(limit).order_by_score())?;
+        let top_docs =
+            searcher.search(&parsed_query, &TopDocs::with_limit(limit).order_by_score())?;
 
         // Create snippet generator for body field
         let snippet_generator =


### PR DESCRIPTION
## Summary

- Single-line fix in `rust-core/verisim-document/src/lib.rs:279`: `TopDocs::with_limit(N)` no longer implements `Collector` in tantivy 0.26 — must select an ordering. `.order_by_score()` preserves existing semantics and return shape.
- Drops the stale tantivy-0.25-era CVE-mitigation comment block from workspace `Cargo.toml`. Both referenced advisories are now resolved by the natural transitive upgrade (lz4_flex 0.11.5 → 0.13.1, lru 0.12.5 → 0.16.4 — verified in `Cargo.lock`).

## Impact on CI

Unblocks **13 of 16 failing checks** on `origin/main` HEAD. Every Rust-side red (cargo test, clippy, cargo doc, cargo audit, cargo deny, llvm-cov, benchmarks compile, both fuzz targets, Rust build validation, Elixir build validation, compile+test, ExCoveralls) cascaded from this one compile error in verisim-document.

Remaining red on main after this lands:
- governance / Workflow security linter + governance / Language / package anti-pattern policy — surface from the standards reusable @861b5e9
- scorecard — token-permissions + code-review signals (systemic, not workflow-config)
- dispatch — dogfood-gate A2ML manifest cosmetic

Those are in scope for separate follow-ups; this PR is the keystone.

## Test plan

- [x] Local cargo check -p verisim-document clean
- [x] Local cargo check --workspace --all-targets clean (26.08s)
- [ ] CI rust-ci / build-validation / fuzz / cargo deny / cargo audit / benchmarks compile / llvm-cov green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)