### PR TITLE
licence(reuse): fix bot_directives PMPL headers → MPL-2.0 (remove masking override)

### DIFF
--- a/.machine_readable/bot_directives/README.a2ml
+++ b/.machine_readable/bot_directives/README.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directives]
 notes = "Repo-specific constraints for verisimdb."

--- a/.machine_readable/bot_directives/echidnabot.a2ml
+++ b/.machine_readable/bot_directives/echidnabot.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directive]
 allow = ["analysis", "fuzzing", "proof checks"]

--- a/.machine_readable/bot_directives/finishbot.a2ml
+++ b/.machine_readable/bot_directives/finishbot.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directive]
 allow = ["release checklists", "docs updates", "metadata fixes", "maintenance reminders"]

--- a/.machine_readable/bot_directives/glambot.a2ml
+++ b/.machine_readable/bot_directives/glambot.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directive]
 allow = ["docs", "readme badges", "ui/accessibility suggestions"]

--- a/.machine_readable/bot_directives/rhodibot.a2ml
+++ b/.machine_readable/bot_directives/rhodibot.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directive]
 allow = ["metadata", "docs", "repo-structure checks", "policy validation"]

--- a/.machine_readable/bot_directives/robot-repo-automaton.a2ml
+++ b/.machine_readable/bot_directives/robot-repo-automaton.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directive]
 allow = ["low-risk automated edits", "build-artifact cleanup", "metadata hygiene"]

--- a/.machine_readable/bot_directives/robot-repo-cleaner.a2ml
+++ b/.machine_readable/bot_directives/robot-repo-cleaner.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directive]
 allow = ["build-artifact cleanup", "cache pruning", "workspace hygiene"]

--- a/.machine_readable/bot_directives/seambot.a2ml
+++ b/.machine_readable/bot_directives/seambot.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directive]
 allow = ["analysis", "contract checks", "docs updates", "integration runbooks"]

--- a/.machine_readable/bot_directives/sustainabot.a2ml
+++ b/.machine_readable/bot_directives/sustainabot.a2ml
@@ -1,9 +1,8 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 #
 # Converted from .scm format
 
-# SPDX-License-Identifier: PMPL-1.0-or-later
 
 [bot-directive]
 allow = ["analysis", "reporting", "docs updates", "resource-efficiency recommendations"]

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -259,13 +259,6 @@ SPDX-License-Identifier = "MPL-2.0"
 #    These suppress erroneous/non-SPDX in-file tags.
 # ---------------------------------------------------------------------------
 
-# bot_directives: override PMPL-1.0-or-later (private licence, not in SPDX)
-# with MPL-2.0 so reuse does not need a PMPL licence text file.
-[[annotations]]
-path = ".machine_readable/bot_directives/**"
-precedence = "override"
-SPDX-FileCopyrightText = "2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>"
-SPDX-License-Identifier = "MPL-2.0"
 
 # json-schema: the $comment field contains `MPL-2.0"` (trailing quote) which
 # REUSE parses as an invalid expression. Override so REUSE.toml is authoritative.


### PR DESCRIPTION
## What & why
`reuse lint` on `main` was **green over a lie**. The 9 `.machine_readable/bot_directives/*.a2ml` files carry `SPDX-License-Identifier: PMPL-1.0-or-later` (double-stamped, lines 1 *and* 6) — pulled in by **#114**'s `.scm`→`.a2ml` migration — and **#115**'s `REUSE.toml` added an `override` annotation that re-declared them MPL-2.0, so `reuse lint` passed while the files still said PMPL.

## This PR (the honest fix)
- Flip all 9 headers `PMPL-1.0-or-later` → `MPL-2.0` (the MPL-everywhere policy).
- Remove the **duplicate 2nd SPDX stamp** in each file.
- Delete the **masking `REUSE.toml` override** for `bot_directives/**` (the `**/*.a2ml` glob already covers them, now honestly).
- **Verified:** `reuse lint` PASS 741/741, `grep 'SPDX-License-Identifier: PMPL'` → **0**. Green now reflects reality.

## Left untouched (on purpose)
`PMPL` in `docs/business/**` is **marketing prose** (it positions the product's *"Community Edition (PMPL)"* with an "MPL-2.0 fallback"), not a licence header — see the discrepancy note below; rewriting marketing copy isn't in scope here.

## Two lessons (tracked separately)
1. The estate `governance / Licence consistency` check **passed #114 despite PMPL headers** — it doesn't catch non-SPDX identifiers. Gap.
2. A `REUSE.toml` `override` can mask an in-file licence lie. This is exactly why the **Nickel/k9 Layer-2 policy** (one-SPDX-per-file, valid-per-path, no masking) from the gate design is needed on top of `reuse lint`.

https://claude.ai/code/session_01W9Voe3JceP66Bna9FT4jME

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9Voe3JceP66Bna9FT4jME)_