### PR TITLE
chore(machine-readable): add .machine_readable/contractiles 6-verb set + anchor (gap-fill after #114)

### DIFF
--- a/.machine_readable/anchors/ANCHOR.a2ml
+++ b/.machine_readable/anchors/ANCHOR.a2ml
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MPL-2.0
+# ⚓ ANCHOR: verisimdb
+# This is the canonical authority for the VeriSimDB repository.
+#
+# Modelled on the hyperpolymath standards ANCHOR shape (cf. ephapax). Declares
+# identity, clade, SSG posture, and ecosystem relationships. Authoritative:
+# code conforms to this, not the reverse. Last refreshed during the 2026-06-05
+# machine-readable currency pass.
+
+id: "org.hyperpolymath.verisimdb"
+version: "0.0.1"
+clade: "database"
+status: "active"
+
+# ─── Identity ─────────────────────────────────────────────────────────────────
+identity:
+  project: "VeriSimDB"
+  full-name: "Veridical Simulacrum Database"
+  kind: "database"
+  one-sentence: >
+    A cross-system entity consistency engine: one entity held simultaneously
+    across eight modalities (the octad — Graph, Vector, Tensor, Semantic,
+    Document, Temporal, Provenance, Spatial) with drift detection,
+    self-normalisation, and proof-bearing VQL queries.
+  domain: "cross-modal databases / data consistency / formal verification"
+
+# ─── SSG Configuration ──────────────────────────────────────────────────────
+# Unlike SSG-publishing repos (e.g. ephapax → casket/boj-server), VeriSimDB
+# does not currently publish a static site. Source hosting prefers GitLab
+# (user preference); no GitHub Pages / casket build is wired. boj_trigger is
+# false until/unless a docs site is stood up.
+ssg:
+  engine: "none"
+  output_dir: null
+  boj_trigger: false
+  cartridge: null
+  notes: "No SSG publish target configured. Docs live as .adoc under docs/ + repo root."
+
+# ─── Semantic Authority ─────────────────────────────────────────────────────
+semantic-authority:
+  policy: "canonical"
+  owns:
+    - "Octad entity model and cross-modal consistency semantics"
+    - "Drift-detection thresholds and self-normalisation behaviour"
+    - "VQL (VeriSim Query Language) syntax, type system, and proof obligations"
+    - "Contractile invariant definitions (.machine_readable/contractiles/)"
+  authoritative-files:
+    formal-proofs: "formal/ (Coq: Drift.v, Normalizer.v, Provenance.v, Transaction.v, WAL.v, Planner.v, VCL.v)"
+    abi: "src/abi/ (Idris2: Types.idr, Layout.idr, Foreign.idr; 0 believe_me)"
+    known-issues: "KNOWN-ISSUES.adoc"
+    state: ".machine_readable/6a2/STATE.a2ml"
+
+# ─── Implementation Policy ──────────────────────────────────────────────────
+implementation-policy:
+  allowed: ["Rust", "Elixir", "ReScript", "VQL", "Idris2", "Zig", "Coq", "Just", "AsciiDoc"]
+  forbidden: ["Python", "Go", "Node.js"]
+  notes: >
+    Rust core (modality stores), Elixir/OTP orchestration, ReScript VQL parser.
+    A single JS bridge file exists (vql-bridge/vql_parser_port.js) as parser
+    glue. Python is banned (Rust/Julia replace it).
+
+# ─── Golden Path ────────────────────────────────────────────────────────────
+golden-path:
+  smoke-test-command:
+    - "just build"
+    - "just test"
+    - "just test-elixir"
+  success-criteria:
+    - "Rust core builds (cargo build --release)"
+    - "Rust + Elixir test suites pass"
+    - "No AGPL-3.0 headers (just license-check)"
+    - "No unresolved critical security findings"
+
+# ─── Relationships ──────────────────────────────────────────────────────────
+parents:
+  - id: "org.hyperpolymath.standards"
+    relationship: "anchor-template-source"
+
+siblings:
+  - id: "org.hyperpolymath.verisimdb-data"
+    relationship: "git-backed-flatfile-store"
+    note: "Data repo holding panic-attack scans, drift snapshots, dispatch manifests; queried without a running server."
+  - id: "org.hyperpolymath.hypatia"
+    relationship: "integration-consumer"
+    note: "ScanIngester/PatternQuery/DispatchBridge feed the Hypatia neurosymbolic review pipeline."
+  - id: "org.hyperpolymath.panic-attacker"
+    relationship: "upstream-scanner"
+    note: "panic-attack assail produces the JSON ingested as octad entities."
+  - id: "org.hyperpolymath.gitbot-fleet"
+    relationship: "downstream-dispatch"
+    note: "DispatchBridge logs JSONL manifests destined for fleet auto-merge bots."
+
+# ─── Satellite Policy ───────────────────────────────────────────────────────
+satellite-policy:
+  must-pin-upstream: true
+  must-declare-authority: true
+  must-have-anchor: true
+  must-have-golden-path: true
+
+# ─── History ────────────────────────────────────────────────────────────────
+realignment-history:
+  - date: "2026-06-05"
+    event: "anchor-born"
+    session-type: "machine-readable-currency-pass"
+    summary: >
+      ANCHOR.a2ml first written during the estate-wide currency checkpoint.
+      Added alongside the .machine_readable/contractiles/ Verbfile.a2ml set
+      (must/trust/bust/adjust/dust/intend) and the 6a2 refresh. No source code
+      changes. Models the standards/ephapax ANCHOR shape, accurate to VeriSimDB
+      (clade=database, no SSG publish target).

--- a/.machine_readable/contractiles/INDEX.a2ml
+++ b/.machine_readable/contractiles/INDEX.a2ml
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MPL-2.0
+# INDEX.a2ml — Contractile Registry
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Machine-readable catalogue of all contractile verbs in this template set.
+# Consumers (CI scripts, the contractile CLI, Hypatia rules) SHOULD read this
+# file to discover available verbs rather than hard-coding the list.
+#
+# See: docs/CONTRACTILE-SPEC.adoc §Registry
+
+---
+id = "contractiles-registry"
+version = "2.0.0"   # 2.0.0 (2026-04-18): all 6 verbs on trident shape; verb set complete.
+spec = "docs/CONTRACTILE-SPEC.adoc"
+last_updated = "2026-04-18"
+base_schema = ".machine_readable/contractiles/_base.ncl"
+meta_schema_status = "pending — see CONTRACTILE-SPEC §validator-meta-schema"
+
+## Verbs
+
+[[verbs]]
+name = "adjust"
+semantics = "drift tolerances + corrective actions"
+trident = [
+  "adjust/Adjustfile.a2ml",
+  "adjust/adjust.ncl",
+  "adjust/adjust.k9.ncl",
+]
+manifest = "adjust/adjust.manifest.a2ml"
+status = "active"
+tier = "Yard"
+authority = "advisory"
+gating = "advisory (continue-with-warnings)"
+cardinality = "one per repo"
+notes = "Fifth trident instance (2026-04-18). First (Yard, advisory) authority pattern. Specialises in cumulative-drift catchment — tolerance bands + trend tracking across sessions. auto_fix_when_available applies deterministic patches; advisory otherwise."
+
+[[verbs]]
+name = "bust"
+semantics = "hard-stop / expiry / must-not-run declarations"
+trident = [
+  "bust/Bustfile.a2ml",
+  "bust/bust.ncl",
+  "bust/bust.k9.ncl",
+]
+manifest = "bust/bust.manifest.a2ml"
+status = "active"
+tier = "Hunt-read-only"
+authority = "blocking"
+gating = "hard (exit-nonzero)"
+cardinality = "one per repo"
+notes = "Fourth trident instance (2026-04-18). Completes the blocking-authority triple (must + trust + bust). Specialises in deprecated-path-reintroduction catchment. Injects failures via declared probes and verifies recovery paths."
+
+[[verbs]]
+name = "dust"
+semantics = "rollback / recovery / deprecation / audit-trail preservation"
+trident = [
+  "dust/Dustfile.a2ml",
+  "dust/dust.ncl",
+  "dust/dust.k9.ncl",
+]
+manifest = "dust/dust.manifest.a2ml"
+status = "active"
+tier = "Yard"
+authority = "advisory"
+gating = "advisory (continue-with-warnings)"
+cardinality = "one per repo"
+notes = "Sixth and FINAL trident instance (2026-04-18) — completes the full verb set. Specialises in audit-trail preservation + rollback-path verification. Destructive actions gated behind --apply flag + per-item approval; dry-run default."
+
+[[verbs]]
+name = "intend"
+semantics = "north-star (commitments + aspirations)"
+trident = [
+  "intend/Intentfile.a2ml",
+  "intend/intend.ncl",
+  "intend/intend.k9.ncl",
+]
+manifest = "intend/intend.manifest.a2ml"
+status = "active"
+tier = "Hunt"
+authority = "reporting"
+gating = "non-gating (continue)"
+cardinality = "one per repo"
+notes = "First trident instance in the estate (2026-04-18). Reports progress toward committed next-actions AND lists horizon aspirations. Absorbed the deprecated `lust` verb 2026-04-18. Never blocks. Remaining 5 verbs still on file_pair shape until tridents are built."
+
+[[verbs]]
+name = "k9"
+semantics = "trust-tier templates (EXCEPTION to one-verbfile rule)"
+file_pair = [
+  "../svc/self-validating/template-hunt.k9.ncl",
+  "../svc/self-validating/template-kennel.k9.ncl",
+  "../svc/self-validating/template-yard.k9.ncl",
+]
+status = "exception"
+gating = "not applicable"
+notes = "k9 is service-automation meta-infrastructure, not a verb contractile. Three trust-tier templates (Kennel/Yard/Hunt). Does not have a Verbfile.a2ml. Templates live under .machine_readable/svc/self-validating/ (the single k9 home, per PR #114's svc/k9 -> svc/self-validating rename); the verb tridents (intend/adjust .k9.ncl) import them via ../../svc/self-validating/. See CONTRACTILE-SPEC §k9-exception."
+
+# [[verbs]] lust REMOVED 2026-04-18 — name had unwanted associations;
+# the horizon/aspiration semantics were always meant to live inside `intend`
+# (the north-star verb). The [[wishes]] schema was absorbed into
+# intend/Intentfile.a2ml. Any `lust/` dir found in an estate repo is drift
+# and should be deleted.
+
+[[verbs]]
+name = "must"
+semantics = "invariant assertion — release-blocking"
+trident = [
+  "must/Mustfile.a2ml",
+  "must/must.ncl",
+  "must/must.k9.ncl",
+]
+manifest = "must/must.manifest.a2ml"
+status = "active"
+tier = "Hunt-read-only"
+authority = "blocking"
+gating = "hard (exit-nonzero)"
+cardinality = "one per repo"
+notes = "Third trident instance (2026-04-18). Completes the blocking-authority pair with trust: must = concrete + persistent invariants; trust = concrete + ephemeral transactions. Specialises in subtle invariant-erosion (tracking per-session trend; flagging silent regression). Single failure blocks merge. Simplest and most commonly populated verb."
+
+[[verbs]]
+name = "trust"
+semantics = "security + provenance + safe-hacking"
+trident = [
+  "trust/Trustfile.a2ml",
+  "trust/trust.ncl",
+  "trust/trust.k9.ncl",
+]
+manifest = "trust/trust.manifest.a2ml"
+status = "active"
+tier = "Hunt"
+authority = "blocking"
+gating = "hard (exit-nonzero)"
+cardinality = "one per repo"
+notes = "Second trident instance (2026-04-18). First (Hunt, blocking) verb — hard gate. Primary defense against threat-model misclassification (B1) and 'turn off the firewall' capability-collapse (C2). Inherits on_open negotiation+accountability+translation from intend.k9.ncl v2.0.0; adds threat_model_foregrounding + block_session_close_on_critical_drift."

--- a/.machine_readable/contractiles/_base.ncl
+++ b/.machine_readable/contractiles/_base.ncl
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MPL-2.0
+# (MPL-2.0 is automatic legal fallback until PMPL is formally recognised)
+#
+# _base.ncl — Shared contractile base
+#
+# Provides four named schema fragments imported by every verb runner:
+#
+#   pedigree_schema   — canonical pedigree block shape
+#   status_core_doc   — documentation of the shared status trio (String list)
+#   probe_schema      — target structured probe form (spec only; verb files
+#                       still use probe | String with TODO comments)
+#   run_defaults      — default runner behaviour
+#
+# Usage in a verb runner:
+#
+#   let base = import "../_base.ncl" in
+#   {
+#     pedigree = base.pedigree_schema & {
+#       contractile_verb = "must",
+#       semantics = "invariant",
+#       security = {
+#         leash = 'Kennel,
+#         trust_level = "read-only verification",
+#         allow_network = false,
+#         allow_filesystem_write = false,
+#         allow_subprocess = true,
+#       },
+#       metadata = {
+#         name = "must-runner",
+#         version = "1.0.0",
+#         description = "...",
+#         paired_xfile = "Mustfile.a2ml",
+#         author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+#       },
+#     },
+#     schema = { ... },
+#     run = base.run_defaults & { on_any_fail = "exit-nonzero" },
+#   }
+#
+# See: docs/CONTRACTILE-SPEC.adoc §Shared Base
+
+{
+  # -------------------------------------------------------------------------
+  # pedigree_schema
+  #
+  # The canonical shape of the `pedigree` block required in every verb runner.
+  # Verb runners merge this with their verb-specific values using Nickel's `&`
+  # (right-priority merge). Override contractile_verb, semantics, security.*,
+  # and metadata.* in each verb.
+  # -------------------------------------------------------------------------
+  pedigree_schema = {
+    schema_version | String | default = "1.0.0",
+    contractile_verb | String | default = "UNSET",   # MUST override in verb
+    semantics | String | default = "UNSET",           # MUST override in verb
+    security = {
+      leash | [| 'Kennel, 'Yard, 'Hunt |] | default = 'Kennel,
+      trust_level | String | default = "UNSET",       # MUST override in verb
+      allow_network | Bool | default = false,
+      allow_filesystem_write | Bool | default = false,
+      allow_subprocess | Bool | default = true,
+      # verb-specific additional security fields go in the verb's merge override:
+      # e.g. authorised_probes_only (trust), injection_scope (bust),
+      #      destructive_mode_requires_flag (dust)
+    },
+    metadata = {
+      name | String | default = "UNSET",              # MUST override in verb
+      version | String | default = "1.0.0",
+      description | String | default = "UNSET",       # MUST override in verb
+      paired_xfile | String | default = "UNSET",      # MUST override in verb
+      author | String | default = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+  },
+
+  # -------------------------------------------------------------------------
+  # status_core_doc
+  #
+  # Documents the minimum shared status values present in every verb's status
+  # enum: declared, verified, failing.
+  #
+  # Nickel does not support structural enum extension, so verb files reproduce
+  # their full enum verbatim in `schema`. This field serves as documentation
+  # and for tooling that introspects the base.
+  #
+  # Verbs that extend status_core (i.e. all except must + trust):
+  #   adjust:  + 'partial
+  #   bust:    + 'drilled
+  #   dust:    'declared, 'proposed, 'approved, 'removed  (non-standard)
+  #   intend:  intents: 'declared, 'in_progress, 'done, 'deferred, 'retired
+  #            wishes:  'declared, 'in_progress, 'achieved, 'abandoned
+  #            (the wishes schema was absorbed from the deprecated `lust`
+  #             verb 2026-04-18; lust/ dir removed estate-wide)
+  #
+  # See: docs/CONTRACTILE-SPEC.adoc §Per-Verb Extension
+  # -------------------------------------------------------------------------
+  status_core_doc = "status_core values: declared | verified | failing — extended per verb",
+
+  # -------------------------------------------------------------------------
+  # probe_schema
+  #
+  # The TARGET structured probe form. See: docs/CONTRACTILE-SPEC.adoc §Probe
+  #
+  # IMPORTANT: This is a spec-only definition. Existing verb runner files still
+  # use `probe | String` with a `# TODO: migrate to probe_schema` comment.
+  # This is a breaking change; migration happens when the CLI supports both
+  # forms.
+  #
+  # Adopters writing new xfiles should prefer the structured form:
+  #   probe = {
+  #     command = "test -f my-file",
+  #     timeout_seconds = 60,
+  #     allowed_exit_codes = [0],
+  #     permission_class = 'read_only,
+  #   }
+  # -------------------------------------------------------------------------
+  probe_schema = {
+    command | String,
+    timeout_seconds | Number | default = 300,
+    allowed_exit_codes | Array Number | default = [0],
+    permission_class
+      | [| 'read_only, 'filesystem_write, 'subprocess, 'network |]
+      | default = 'read_only,
+  },
+
+  # -------------------------------------------------------------------------
+  # run_defaults
+  #
+  # Default runner behaviour. Verb runners merge this with verb-specific
+  # overrides using Nickel's `&` (right-priority merge).
+  #
+  # Most verbs override on_any_fail:
+  #   "exit-nonzero"          : hard gate  (must, trust, bust, adjust-gating)
+  #   "continue-with-warnings": advisory   (dust, adjust)
+  #   "continue"              : never gate (intend — covers both intents and wishes)
+  # -------------------------------------------------------------------------
+  run_defaults = {
+    on_pass = "continue",
+    on_any_fail = "exit-nonzero",
+    report_format = "a2ml",
+    emit_summary = true,
+  },
+}

--- a/.machine_readable/contractiles/adjust/Adjustfile.a2ml
+++ b/.machine_readable/contractiles/adjust/Adjustfile.a2ml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MPL-2.0
+# Adjustfile — Drift-tolerance + accessibility contract for VeriSimDB
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Tolerance bands + corrective actions. Advisory (continue-with-warnings):
+# progress-tracked, not a hard gate. Deterministic fixes applied where defined.
+# Pairs with: adjust.ncl (same directory)
+# Run with: contractile adjust check   (run probes, list violations)
+#           contractile adjust fix     (apply deterministic fixes where defined)
+
+@abstract:
+Drift tolerances and corrective actions for VeriSimDB. Two registers:
+(1) accessibility of the human-facing surfaces — the VQL Playground and the
+PanLL telemetry dashboard (ReScript); (2) self-normalisation tolerance bands,
+the in-domain analogue of "adjust" for a drift-aware database. Advisory:
+tracked over sessions, never blocks merge.
+@end
+
+## Accessibility — VQL Playground / PanLL Dashboard
+
+### playground-present
+- description: VQL Playground surface exists (human-facing query UI)
+- status: declared
+- probe: test -d playground
+- compliance: WCAG 2.1 AA
+- notes: ReScript ApiClient.res wired to real backend with demo-mode fallback.
+
+### dashboard-keyboard-nav
+- description: PanLL telemetry dashboard panel is keyboard-navigable
+- status: declared
+- probe: test -d playground
+- compliance: WCAG 2.1 AA
+- notes: Modality heatmap + query-pattern panels need full keyboard-only traversal audit.
+- fix: Port the estate keyboard-navigation pattern to the dashboard panel.
+
+### high-contrast-theme
+- description: High-contrast theme available for the playground/dashboard
+- status: declared
+- compliance: WCAG 2.1 AA
+- notes: Not yet implemented; tracked as accessibility horizon.
+- fix: Add CSS contrast-ratio variables (>= 4.5:1).
+
+### reduced-motion
+- description: Heatmap/animation respects prefers-reduced-motion
+- status: declared
+- compliance: WCAG 2.1 AA
+- notes: Telemetry heatmap animates; needs a reduced-motion path.
+
+## Drift-Tolerance Bands (self-normalisation)
+
+### drift-thresholds-configurable
+- description: Drift detection thresholds are configurable (tolerance bands, not hard-coded)
+- status: declared
+- probe: test -d rust-core/verisim-drift
+- notes: semantic_vector / graph_document / temporal / tensor / schema / quality drift each carry a threshold.
+
+### normalizer-trigger-tolerance
+- description: Self-normalisation fires only when drift exceeds the band (avoids thrash)
+- status: declared
+- probe: test -d rust-core/verisim-normalizer
+- notes: Cumulative-drift catchment — trend across sessions, flag accelerating drift.
+
+### coverage-floor-band
+- description: Elixir test-coverage stays at or above the agreed floor (ramp band)
+- status: partial
+- compliance: project ramp target
+- notes: Floor 40, current ~42.6 per coveralls; ramp to 50 (2026-07-15) then 60 (2026-09-01). See elixir-orchestration coverage ramp doc.
+
+## Documentation Adjustments
+
+### accessibility-guide
+- description: User-facing accessibility guide for the playground
+- status: declared
+- target: docs/ accessibility guide
+- notes: Keyboard shortcuts, screen-reader setup, theme switching.

--- a/.machine_readable/contractiles/adjust/adjust.k9.ncl
+++ b/.machine_readable/contractiles/adjust/adjust.k9.ncl
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: MPL-2.0
+# adjust.k9.ncl — K9 trust-tier component of the adjust trident
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Pairs with: Adjustfile.a2ml (declaration) + adjust.ncl (runner).
+#
+# Verb:       adjust          (drift tolerances + corrective actions)
+# Tier:       Yard            (validation with subprocess for measurement;
+#                              no mutation beyond auto-fix where declared)
+# Authority:  advisory        (continue-with-warnings; not blocking)
+#
+# adjust is the tolerance-band verb. Where must says "this MUST hold"
+# and trust says "this MUST verify clean" (both binary), adjust says
+# "drift ≤ X is acceptable; drift > X triggers action Y". Between them,
+# adjust handles the subtle-drift territory that binary verbs can't.
+#
+# Cardinality: ONE adjust trident per repo.
+#
+# Failure-mode focus: adjust catches cumulative-small-drift patterns
+# (E2 cosmetic churn accumulating into real regression, F2 context
+# erosion causing gradual parameter drift). Where must flags "broken
+# now", adjust flags "drifting toward broken".
+
+let base_k9 = import "../../svc/self-validating/template-hunt.k9.ncl" in
+let base    = import "../_base.ncl" in
+
+{
+  pedigree = base_k9.pedigree_schema & {
+    contractile_verb = "adjust",
+    paired_xfile     = "../adjust/Adjustfile.a2ml",
+    paired_runner    = "../adjust/adjust.ncl",
+
+    tier      = 'Yard,
+    authority = 'advisory,
+
+    metadata = {
+      name = "adjust-k9",
+      version = "1.0.0",
+      description = "Drift-tolerance + corrective-action runner. Fifth trident instance. First (Yard, advisory) authority pattern.",
+      paired_xfile = "Adjustfile.a2ml",
+      paired_runner = "adjust.ncl",
+      author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+
+    security = {
+      leash = 'Yard,
+      trust_level = "tolerance measurement + declared auto-fix",
+      allow_network = false,
+      allow_filesystem_write_conditional = true,  # auto_fix_when_available may edit
+      allow_subprocess = true,
+      probe_scope = 'measurement_plus_declared_fix,
+    },
+  },
+
+  variance_schema = {
+    entry_id     | String,
+    reason       | String,
+    approved_by  | String,
+    scope        | String,
+    expires      | String,
+    review_notes | String | optional,
+    # adjust-specific: which tolerance band the variance widens
+    tolerance_band_widened | String,
+    widened_to_value | String,
+  },
+
+  execution = {
+    triggers = [ 'session_close, 'on_demand, 'pre_push ],
+
+    per_tolerance = {
+      measure_drift = true,
+      record_outcome = true,
+      respect_variance = true,
+      # adjust-specific authority: tolerance exceeded → warn, try
+      # auto-fix if declared, then continue. Never blocks.
+      on_exceeded = 'warn_and_attempt_fix,
+      on_auto_fix_applied = 'record_and_continue,
+      on_auto_fix_unavailable = 'record_as_advisory_drift,
+      # Cumulative-drift detection (adjust's specialty)
+      track_drift_trend_over_sessions = true,
+      flag_accelerating_drift = true,
+    },
+
+    evidence_sinks = [
+      { kind = 'verisimdb, table = "contractile_executions",
+        schema = "contractile_execution_v1",
+        aux_tables = [ "adjust_drift_history" ] },
+      { kind = 'drift_log, path = ".machine_readable/6a2/DRIFT.a2ml",
+        append_only = true },
+    ],
+
+    on_close = {
+      re_measure_all_tolerances = true,
+      diff_against_last_ratification = true,
+      emit_drift_entries_for_tolerance_exceeded = true,
+      surface_expired_variances = true,
+      surface_accelerating_drift = true,
+      # adjust is advisory — does NOT block session close.
+      block_session_close_on_any_drift = false,
+    },
+
+    on_open = {
+      render_summary = 'plain_language,
+      include_drift_log_from_last_close = true,
+      include_active_variances = true,
+      include_recent_anchors = true,
+      anchor_lookback_weeks = 8,
+      include_tolerance_trend_summary = true,
+
+      negotiation = {
+        required = true,
+        ai_required_inputs = [
+          'timeline_realism,
+          'industry_standards,
+          'audience_feasibility,
+          'resulting_invariants,
+          'ecosystem_dependencies,
+        ],
+        user_engagement_required = true,
+        user_engagement_mode = 'per_input_response,
+        specification_translation = {
+          ai_produces_spec_form = true,
+          user_reviews_in_domain_language = true,
+          schema_authoring_is_ai_responsibility = true,
+          translation_faithfulness_auditable = true,
+        },
+      },
+
+      accountability_pledge = {
+        required = true,
+        parties = [
+          {
+            role = 'user,
+            pledge = "I have reviewed the tolerance bands and corrective actions. I accept accountability for reviewing drift warnings rather than muting them, and for re-tuning tolerances via amendment when the intended operating envelope changes.",
+            signature_required = true,
+          },
+          {
+            role = 'ai_agent,
+            pledge = "I will surface tolerance breaches and accelerating-drift patterns at session close; I will propose corrective actions rather than widening tolerances silently; I will require amendment for legitimate tolerance re-tuning, not quiet band-widening.",
+            signature_required = true,
+          },
+        ],
+        signed_record_destination = ".machine_readable/6a2/ratification-<session-id>.a2ml",
+        must_precede_work = true,
+      },
+
+      ratification_record_shape = {
+        includes_negotiation_transcript = true,
+        includes_both_pledges = true,
+        includes_tolerance_bands_snapshot = true,
+        signed = true,
+        dated = true,
+        session_id = 'required,
+        contract_hash = 'required,
+      },
+    },
+  },
+
+  failure_mode_defenses = [
+    'A1_enthusiasm_capture,
+    'C3_helpfulness_inflation,      # helpful additions surfaced if they widen tolerances silently
+    'C4_modernization_drift,
+    'E2_cosmetic_churn,             # adjust tracks cumulative churn
+    'F2_context_window_erosion,     # parameter drift across sessions detected
+  ],
+}

--- a/.machine_readable/contractiles/adjust/adjust.manifest.a2ml
+++ b/.machine_readable/contractiles/adjust/adjust.manifest.a2ml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MPL-2.0
+# adjust.manifest.a2ml — Trident coherence manifest for the adjust verb.
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Fifth trident instance. First (Yard, advisory) authority pattern —
+# complements the (Hunt, blocking) triple (must + trust + bust) and
+# the (Hunt, reporting) north-star (intend).
+
+---
+trident_version = "1.0.0"
+verb = "adjust"
+semantics = "drift tolerances + corrective actions"
+cardinality = "one per repo"
+authority = "advisory (continue-with-warnings)"
+
+[[files]]
+role = "declaration"
+path = "Adjustfile.a2ml"
+sha256 = "pending-first-verify"
+size_bytes = "pending-first-verify"
+
+[[files]]
+role = "runner"
+path = "adjust.ncl"
+sha256 = "pending-first-verify"
+size_bytes = "pending-first-verify"
+
+[[files]]
+role = "k9_component"
+path = "adjust.k9.ncl"
+sha256 = "pending-first-verify"
+size_bytes = "pending-first-verify"
+
+[cross_refs]
+runner_paired_xfile = "Adjustfile.a2ml"
+k9_paired_xfile     = "../adjust/Adjustfile.a2ml"
+k9_paired_runner    = "../adjust/adjust.ncl"
+
+[signed_by]
+user    = "Jonathan D.A. Jewell"
+date    = "2026-04-18"
+context = "adjust trident — fifth Trident instance. First (Yard, advisory) authority pattern. Specialises in cumulative-drift catchment — tolerance bands + trend tracking + auto-fix-where-declared."
+
+[[history]]
+date = "2026-04-18"
+event = "trident-born"
+note = "Adjustfile.a2ml and adjust.ncl pre-existed. This manifest + adjust.k9.ncl complete the trident. Exercises the Yard tier + advisory authority for the first time; on_exceeded = 'warn_and_attempt_fix rather than 'fail. adjust-specific track_drift_trend_over_sessions + flag_accelerating_drift."

--- a/.machine_readable/contractiles/adjust/adjust.ncl
+++ b/.machine_readable/contractiles/adjust/adjust.ncl
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MPL-2.0
+# Adjust — accessibility runner
+#
+# Pairs with: Adjustfile.a2ml (same directory)
+# Verb:       adjust
+# Semantics:  accessibility compliance (WCAG 2.1 AA baseline). Gating where
+#             a deterministic fix exists; advisory where human review needed.
+# CLI:        `contractile adjust check` → run all probes, list violations
+#             `contractile adjust fix`   → apply deterministic fixes where defined
+#
+# Anything else in this directory is human-only notes/archive; machines ignore.
+#
+# Base: ../_base.ncl provides pedigree_schema, run_defaults, probe_schema.
+# See: docs/CONTRACTILE-SPEC.adoc
+
+let base = import "../_base.ncl" in
+
+{
+  pedigree = base.pedigree_schema & {
+    contractile_verb = "adjust",
+    semantics = "accessibility compliance",
+    security = {
+      leash = 'Kennel,
+      trust_level = "fixes allowed where deterministic",
+      allow_network = false,
+      allow_filesystem_write = true,    # `adjust fix` may write (deterministic patches only)
+      allow_subprocess = true,
+    },
+    metadata = {
+      name = "adjust-runner",
+      version = "1.0.0",
+      description = "Evaluates accessibility requirements from Adjustfile.a2ml. Fixes deterministic items; flags the rest for human review.",
+      paired_xfile = "Adjustfile.a2ml",
+      author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+  },
+
+  schema = {
+    requirements
+      | Array {
+          id | String,
+          description | String,
+          # TODO: migrate to base.probe_schema (structured probe) when CLI supports it
+          probe | String,
+          # status_core values: 'declared, 'verified, 'failing; adjust adds 'partial
+          status | [| 'declared, 'partial, 'verified, 'failing |] | default = 'declared,
+          compliance | String | optional,       # e.g. "WCAG 2.1 AA"
+          notes | String | optional,
+          fix | String | optional,              # deterministic fix command (optional)
+        },
+  },
+
+  # Runner behaviour — inherits from base.run_defaults.
+  # adjust is advisory (continue-with-warnings) not a hard gate.
+  # auto_fix_when_available is adjust-specific.
+  run = base.run_defaults & {
+    on_any_fail = "continue-with-warnings",   # accessibility is progress-tracked, not a hard gate by default
+    report_format = "a2ml",
+    emit_summary = true,
+    auto_fix_when_available = true,
+  },
+}

--- a/.machine_readable/contractiles/bust/Bustfile.a2ml
+++ b/.machine_readable/contractiles/bust/Bustfile.a2ml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MPL-2.0
+# Bustfile — Error-handling / failure-recovery contract for VeriSimDB
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Declared failure modes and their recovery paths. Hard gate on any failure
+# mode without a working, exercised recovery.
+# Pairs with: bust.ncl (same directory)
+# Run with: contractile bust check   (list failure modes + recovery status)
+#           contractile bust drill   (inject declared failures, verify recovery)
+
+@abstract:
+Failure modes for VeriSimDB and the recovery paths that must hold. The octad
+keeps eight synchronised stores plus a WAL; drift detection + self-normalisation
+are the in-band recovery mechanisms. Each failure mode below names a recovery
+probe; the drill harness injects the failure and verifies recovery. Injection
+is scoped to the system-under-test only.
+@end
+
+## Persistence & Crash Recovery
+
+### wal-replay-after-crash
+- description: WAL replay restores observable state after an unclean shutdown
+- class: crash
+- run: test -d rust-core/verisim-wal
+- severity: critical
+- recovery: WAL replay is idempotent on observable state (Coq: formal/WAL.v, C7 wal_replay_idempotent, PR #94)
+- notes: Recovery proof mechanised; drill exercises replay against a repo-local store.
+
+### redb-backend-available
+- description: Pure-Rust redb backend present as fallback when Oxigraph feature is off
+- class: disk_full
+- run: test -d rust-core/verisim-storage
+- severity: high
+- recovery: redb backend is feature-flagged; no oxrocksdb-sys C++ dependency (resolved, see CLAUDE.md known-issues)
+
+## Cross-Modal Consistency Drift
+
+### drift-detector-bounds
+- description: Drift detector keeps scores in the unit interval and triggers normalisation
+- class: concurrency
+- run: test -d rust-core/verisim-drift
+- severity: high
+- recovery: Self-normalizer regenerates drifted modalities from the most authoritative one (formal/Drift.v D1 unit-interval, formal/Normalizer.v N2 normalize_idempotent, PRs #90/#95)
+
+### normalizer-idempotent
+- description: Re-running normalisation on a consistent octad is a no-op
+- class: partial_write
+- run: test -d rust-core/verisim-normalizer
+- severity: high
+- recovery: normalize_idempotent mechanised (formal/Normalizer.v, closes #91)
+
+## Transaction State Machine
+
+### txn-state-machine-recovery
+- description: Aborted/partial transactions return the store to a valid prior state
+- class: rollback
+- run: test -f formal/Transaction.v
+- severity: high
+- recovery: Transaction state machine mechanised (formal/Transaction.v C2, PR #90)
+
+## Federation / NIF Bridge
+
+### rust-core-unavailable-fallback
+- description: Elixir layer degrades to ETS fallback when the Rust core/NIF is unavailable
+- class: network
+- run: test -f elixir-orchestration/lib/verisim/nif_bridge.ex
+- severity: medium
+- recovery: ScanIngester + Hypatia modules fall back to ETS (:hypatia_scans) when Rust core is down (CLAUDE.md Hypatia Integration)
+- notes: Degraded-mode path, not a hard outage; OTP supervision restarts the bridge.
+
+## Rollback Ladder
+
+### git-revert-is-floor
+- description: First-line recovery for a bad change is git revert (reversible, low blast radius)
+- class: rollback
+- run: git rev-parse --is-inside-work-tree
+- severity: low
+- recovery: revert the offending commit; force-push to main is PROHIBITED without explicit human confirmation (branch protection)

--- a/.machine_readable/contractiles/bust/bust.ncl
+++ b/.machine_readable/contractiles/bust/bust.ncl
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MPL-2.0
+# Bust — error-handling / failure-recovery runner
+#
+# Pairs with: Bustfile.a2ml (same directory)
+# Verb:       bust
+# Semantics:  every declared failure mode must have a recovery path that has
+#             been exercised. Runner injects failures (via declared probes)
+#             and verifies the recovery path works. Hard gate on any
+#             failure-mode with missing or broken recovery.
+# CLI:        `contractile bust check`  → list failure modes + recovery status
+#             `contractile bust drill`  → inject declared failures, verify recovery
+#
+# Anything else in this directory is human-only notes/archive; machines ignore.
+#
+# Base: ../_base.ncl provides pedigree_schema, run_defaults, probe_schema.
+# See: docs/CONTRACTILE-SPEC.adoc
+
+let base = import "../_base.ncl" in
+
+{
+  pedigree = base.pedigree_schema & {
+    contractile_verb = "bust",
+    semantics = "error handling + failure recovery",
+    security = {
+      leash = 'Kennel,
+      trust_level = "controlled failure injection; scoped to system-under-test",
+      allow_network = false,
+      allow_filesystem_write = true,      # drills may write transient state (tmp dirs, test DBs)
+      allow_subprocess = true,
+      injection_scope = "system-under-test-only",
+    },
+    metadata = {
+      name = "bust-runner",
+      version = "1.0.0",
+      description = "Exercises declared failure modes and verifies recovery paths. Hard-gates on any failure mode without working recovery.",
+      paired_xfile = "Bustfile.a2ml",
+      author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+  },
+
+  schema = {
+    failure_modes
+      | Array {
+          id | String,
+          description | String,
+          class | [| 'network, 'disk_full, 'oom, 'timeout, 'partial_write, 'panic, 'crash, 'rollback, 'concurrency |],
+          # TODO: migrate to base.probe_schema (structured probe) when CLI supports it
+          injection_probe | String,          # command that deterministically causes this failure
+          # TODO: migrate to base.probe_schema (structured probe) when CLI supports it
+          recovery_probe | String,           # command that verifies recovery (exit 0 = recovered)
+          expected_recovery_time_seconds | Number | default = 30,
+          # status_core values: 'declared, 'verified, 'failing; bust adds 'drilled
+          status | [| 'declared, 'drilled, 'verified, 'failing |] | default = 'declared,
+          notes | String | optional,
+        },
+  },
+
+  # Runner behaviour — inherits from base.run_defaults.
+  # bust adds record_recovery_times for performance tier feeding.
+  run = base.run_defaults & {
+    on_any_fail = "exit-nonzero",         # missing or broken recovery blocks merge
+    report_format = "a2ml",
+    emit_summary = true,
+    record_recovery_times = true,         # feeds the performance tier
+  },
+}

--- a/.machine_readable/contractiles/dust/Dustfile.a2ml
+++ b/.machine_readable/contractiles/dust/Dustfile.a2ml
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MPL-2.0
+# Dustfile — Exnovation / cleanup contract for VeriSimDB
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Removal candidates and hygiene items. Advisory (continue-with-warnings):
+# housekeeping, not blockers. Destructive sweeps gated behind --apply.
+# Pairs with: dust.ncl (same directory)
+# Run with: contractile dust find          (list removal candidates)
+#           contractile dust sweep         (dry-run)
+#           contractile dust sweep --apply  (execute, gated + per-item approval)
+
+@abstract:
+Exnovation targets and hygiene items for VeriSimDB. Covers stale template
+residue, dropped components, and tracked build artefacts. Advisory by default;
+nothing is deleted without --apply and per-item approval. Audit trail preserved.
+@end
+
+## Template Residue
+
+# (cleared) The 6a2 rsr-template residue previously tracked here was removed by
+# PR #114 (de-templatize machine_readable + honest STATE). ECOSYSTEM.a2ml and
+# META.a2ml now carry VeriSimDB-specific content with no template boilerplate;
+# verified clean on the 2026-06-05 rebuild. No open template-residue items.
+
+## Dropped / Superseded Components
+
+### gleam-sdk-residue
+- description: Gleam client SDK was dropped (PR #85) — no Gleam residue should remain
+- target: connectors/clients
+- reason: Gleam SDK removed in "chore(rot): flush silent failures + drop Gleam SDK"
+- probe: test -z "$(find connectors/clients -iname '*gleam*' -not -path '*/.git/*' 2>/dev/null)"
+- status: declared
+- severity: info
+
+### top-level-contractiles-extensionless
+- description: Top-level contractiles/{must,trust,dust}/<Verb>file (no extension) predate the .machine_readable trident
+- target: contractiles/
+- reason: Older extensionless convention; canonical trident now lives under .machine_readable/contractiles/
+- status: declared
+- severity: info
+- notes: Owner-review item — do NOT delete this pass; the .machine_readable set is the evolving canonical map.
+
+## Build Artefacts
+
+### no-tracked-rust-target
+- description: No Rust target/ build output tracked in git
+- target: target/
+- reason: Build artefacts must not be committed
+- probe: test -z "$(git ls-files 'target/' 'rust-core/target/' 2>/dev/null)"
+- status: declared
+- severity: warning
+
+### no-tracked-elixir-build
+- description: No Elixir _build/ or deps/ tracked in git
+- target: elixir-orchestration/_build
+- reason: Build artefacts must not be committed
+- probe: test -z "$(git ls-files 'elixir-orchestration/_build/' 'elixir-orchestration/deps/' 2>/dev/null)"
+- status: declared
+- severity: warning
+
+### no-tracked-rescript-mjs
+- description: No compiled ReScript .res.mjs output tracked in git
+- target: src/vql
+- reason: Compiled output regenerated from .res sources
+- probe: test -z "$(git ls-files '*.res.mjs' 2>/dev/null)"
+- status: declared
+- severity: info
+
+## Stale Snapshots
+
+### no-dated-status-files
+- description: No dated STATUS/COMPLETION markdown snapshots in root
+- target: ./*-STATUS-*.md
+- reason: Superseded by 6a2/STATE.a2ml and ROADMAP.md
+- probe: test -z "$(ls *-STATUS-*.md *-COMPLETION-*.md 2>/dev/null)"
+- status: declared
+- severity: info

--- a/.machine_readable/contractiles/dust/dust.ncl
+++ b/.machine_readable/contractiles/dust/dust.ncl
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MPL-2.0
+# Dust — exnovation / code-removal runner
+#
+# Pairs with: Dustfile.a2ml (same directory)
+# Verb:       dust
+# Semantics:  exnovation. Identifies code, docs, files, dependencies that are
+#             candidates for REMOVAL. Advisory by default; can be flipped to
+#             active delete via `contractile dust sweep --apply`.
+# CLI:        `contractile dust find`   → list removal candidates
+#             `contractile dust sweep`  → dry-run removals
+#             `contractile dust sweep --apply` → actually delete (gated)
+#
+# Anything else in this directory is human-only notes/archive; machines ignore.
+#
+# Base: ../_base.ncl provides pedigree_schema, run_defaults, probe_schema.
+# See: docs/CONTRACTILE-SPEC.adoc
+
+let base = import "../_base.ncl" in
+
+{
+  pedigree = base.pedigree_schema & {
+    contractile_verb = "dust",
+    semantics = "exnovation / removal",
+    security = {
+      leash = 'Kennel,
+      trust_level = "proposes deletion; --apply required to execute",
+      allow_network = false,
+      allow_filesystem_write = true,      # --apply mode writes (deletes)
+      allow_subprocess = true,
+      destructive_mode_requires_flag = "--apply",
+    },
+    metadata = {
+      name = "dust-runner",
+      version = "1.0.0",
+      description = "Identifies and optionally removes exnovation targets listed in Dustfile.a2ml. Destructive mode gated behind --apply.",
+      paired_xfile = "Dustfile.a2ml",
+      author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+  },
+
+  schema = {
+    removal_candidates
+      | Array {
+          id | String,
+          description | String,
+          target | String,                 # file / path / symbol / dep name
+          reason | String,                 # why it's a removal candidate
+          # TODO: migrate to base.probe_schema (structured probe) when CLI supports it
+          probe | String | optional,       # command that confirms it's still removable
+          # dust has a non-standard status progression (no 'verified):
+          #   'declared → 'proposed → 'approved → 'removed
+          status | [| 'declared, 'proposed, 'approved, 'removed |] | default = 'declared,
+          approver | String | optional,    # who signed off (for 'approved / 'removed)
+          notes | String | optional,
+        },
+  },
+
+  # Runner behaviour — inherits from base.run_defaults.
+  # dust is advisory; apply_requires_approval is dust-specific.
+  run = base.run_defaults & {
+    on_any_fail = "continue-with-warnings",
+    report_format = "a2ml",
+    emit_summary = true,
+    apply_requires_approval = true,       # only 'approved items get swept, even with --apply
+  },
+}

--- a/.machine_readable/contractiles/intend/Intentfile.a2ml
+++ b/.machine_readable/contractiles/intend/Intentfile.a2ml
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MPL-2.0
+# Intentfile — North-star contract for VeriSimDB
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Committed next-actions ([[intents]]) and horizon aspirations ([[wishes]]).
+# Non-gating: reports progress, never blocks.
+# Pairs with: intend.ncl (same directory)
+# Run with: contractile intend run        (status table)
+#           contractile intend progress   (declared vs observed)
+#           contractile intend horizon     (wishes grouped by near/mid/far)
+
+@abstract:
+Declared intent and north-star for VeriSimDB — a cross-system entity
+consistency engine maintaining eight synchronised modalities (the octad) with
+drift detection, self-normalisation, and proof-bearing VQL queries. Standalone
+database OR heterogeneous federation coordinator.
+@end
+
+## Purpose
+
+VeriSimDB keeps one entity consistent across Graph, Vector, Tensor, Semantic,
+Document, Temporal, Provenance and Spatial representations, detecting and
+repairing drift before it degrades data quality, and answering VQL queries that
+carry formal proof obligations.
+
+## Anti-Purpose
+
+This project is NOT:
+- A SQL database (VQL is the native query interface, not SQL)
+- A single-modality store (the octad is the floor — eight modalities per entity)
+- A Python/Go codebase (Rust core + Elixir/OTP orchestration + ReScript VQL only)
+
+## If In Doubt
+
+Sensitive areas: the formal/ Coq proofs (drift/normalizer/WAL/transaction/
+provenance/planner), the VQL type checker (Elixir + ReScript + Rust ZKP bridge),
+license headers, and the NIF bridge between Elixir and the Rust core. Ask before
+changing proof statements or proof-bearing query semantics.
+
+## Intents
+
+### fleet-dispatch-live
+- description: Move Hypatia fleet dispatch from JSONL-logged to live GraphQL mutations
+- status: declared
+- notes: Requires a GitHub PAT with repo scope; see verisimdb-data/INTEGRATION.md. DispatchBridge already logs JSONL manifests + outcomes.
+
+### elixir-coverage-ramp
+- description: Raise Elixir test coverage from ~42.6% to the phase-1 floor of 50%
+- status: in_progress
+- target_date: 2026-07-15
+- notes: Floor currently 40; ramp doc elixir-orchestration/coveralls-coverage-targets.md (phase 2 → 60% by 2026-09-01).
+
+### github-ci-flatfile-store
+- description: Stand up the git-backed verisimdb-data flat-file store + ingest workflow
+- status: declared
+- notes: repository_dispatch ingest.yml + reusable scan-and-report.yml; pilot on echidna / panic-attacker / ambientops.
+
+### main-branch-green
+- description: Keep main CI fully green (last residual was license, closed via #82/#101)
+- status: in_progress
+- notes: 5-of-7 reds cleared in PR #99; license normalised in #101. Watch for regression.
+
+### foundation-pack-followups
+- description: Continue mechanising the formal foundation pack beyond the 8/8 landed lemmas
+- status: declared
+- notes: D1/D2/C2/C7/N2/P2/P3/P4/Q1/V2 landed (PRs #87–#103). Next: wire echo-types cross-doc obligations.
+
+## Wishes
+
+### persistent-server-fly
+- description: Deploy verisim-api to a persistent host (Fly.io free tier) beyond flat files
+- horizon: mid
+- why: GitHub Actions could call a live endpoint instead of repository_dispatch; keep verisimdb-data as mirror
+- status: declared
+
+### model-router-tool
+- description: Build the Haiku-classifier model-router CLI (route tasks Haiku/Sonnet/Opus)
+- horizon: mid
+- why: Auto-select Claude model by task complexity using per-repo CLAUDE.md signals
+- status: declared
+
+### tensor-modality-applications
+- description: Land novel applications of the Tensor modality (active research)
+- horizon: far
+- why: Tensor is the least-developed octad facet; details forthcoming
+- status: declared
+
+### federation-adapters-ga
+- description: Promote the 7 federation adapters (Mongo/Redis/Neo4j/ClickHouse/SurrealDB/Influx/MinIO) to GA-grade
+- horizon: mid
+- why: 105 integration tests exist behind the test-infra stack; harden for production federation
+- status: declared

--- a/.machine_readable/contractiles/intend/intend.k9.ncl
+++ b/.machine_readable/contractiles/intend/intend.k9.ncl
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: MPL-2.0
+# intend.k9.ncl — K9 trust-tier component of the intend trident
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Pairs with: Intentfile.a2ml (declaration) + intend.ncl (runner).
+# Trident completeness is a hard precondition — a repo shipping
+# Intentfile without this file AND its runner is an invalid trident;
+# the contractile CLI's verify gate refuses partial publication.
+#
+# Verb:       intend          (north star — commitments + aspirations)
+# Tier:       Hunt            (capability: subprocess probes may shell out)
+# Authority:  reporting       (never blocks; drift-log only)
+#
+# Cardinality: ONE intend trident per repo (see feedback_contractile_
+# layout_rules.md). ANCHOR.a2ml is the sole multi-instance exception —
+# it is NOT a verb contractile.
+#
+# Design commitments baked in (see memory trail 2026-04-18 for full
+# context; key files referenced by name in annotations below):
+# * α two-axis (tier × authority) — structurally separate capability
+#   from authority so "Hunt tier = can override" is impossible.
+# * Variance schema first-class, not comment markers
+#   (feedback_audit_tool_suppression_design.md — structural > markers).
+# * Sessional drift detection hooks (on_close, on_open).
+# * Ratification at session open; drift log at session close.
+# * Evidence sinks: VeriSimDB (queryable) + 6a2/DRIFT.a2ml (repo-local).
+# * Failure-mode defenses cross-referenced to the AI failure catalog.
+
+let base_k9 = import "../../svc/self-validating/template-hunt.k9.ncl" in
+let base    = import "../_base.ncl" in
+
+{
+  pedigree = base_k9.pedigree_schema & {
+    contractile_verb = "intend",
+    paired_xfile     = "../intend/Intentfile.a2ml",
+    paired_runner    = "../intend/intend.ncl",
+
+    # α two-axis declaration — capability × authority.
+    # intend is Hunt-capable (probes shell out) but reporting-authority
+    # (never blocks). must/trust/bust will declare (Hunt, blocking);
+    # adjust/dust will declare (Yard, advisory). Splitting the axes
+    # means "I'm Hunt-tier so I can override everything" is structurally
+    # impossible — authority is a separate field.
+    tier      = 'Hunt,
+    authority = 'reporting,
+
+    metadata = {
+      name = "intend-k9",
+      version = "2.0.0",             # 1.0.0 (2026-04-18 AM): initial trident.
+                                     # 2.0.0 (2026-04-18 PM): negotiation +
+                                     # accountability + plain-language-translation
+                                     # schema baked into on_open — prerequisite for
+                                     # the adversarial Gemini+Copilot drift pilot.
+      description = "Executes Intentfile probes + emits drift log. Non-gating; reporting authority only. on_open hook implements negotiation-ratification-accountability protocol.",
+      paired_xfile = "Intentfile.a2ml",
+      paired_runner = "intend.ncl",
+      author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+
+    security = {
+      leash = 'Hunt,
+      trust_level = "subprocess + filesystem-read",
+      allow_network = false,
+      allow_filesystem_write = false,   # evidence sinks are indirected
+      allow_subprocess = true,
+    },
+  },
+
+  # -------------------------------------------------------------------
+  # Variance schema — P-shape scoped exceptions per entry.
+  # A variance suppresses a specific intent's or wish's obligation for a
+  # reason, with approver + expiry. Expired variance = effective
+  # re-imposition of the obligation. Unmet intent without a variance =
+  # drift, logged to the drift log.
+  # Per user 2026-04-18: variances are structural, not magic-comment
+  # markers — markers are gameable.
+  # -------------------------------------------------------------------
+  variance_schema = {
+    entry_id     | String,   # which intent/wish id the variance applies to
+    reason       | String,
+    approved_by  | String,
+    scope        | String,   # path glob | session-id | "until-<date>"
+    expires      | String,   # absolute date or condition
+    review_notes | String | optional,
+  },
+
+  # -------------------------------------------------------------------
+  # Execution policy
+  # -------------------------------------------------------------------
+  execution = {
+    # When the component runs.
+    # session_close is mandatory (the "picked up sessionally" check).
+    triggers = [ 'session_close, 'on_demand, 'pre_push ],
+
+    # Per-intent execution.
+    per_intent = {
+      run_probe = true,
+      record_outcome = true,
+      respect_variance = true,    # active variance suppresses failure
+      on_unmet = 'log_drift,      # never 'fail — authority = reporting
+    },
+
+    # Per-wish execution (wishes are non-probeable; horizon-group only).
+    per_wish = {
+      run_probe = false,
+      emit_horizon_summary = true,
+      # Vertical alignment soft-check per user_6a2_is_contractile_ought.md:
+      # highest-level alignment is meta ↔ north-star (soft), not hard gate.
+      check_alignment_with_META = true,
+    },
+
+    # Evidence sinks — BOTH written, every execution.
+    # VeriSimDB = queryable machine record (feedback_verisimdb_policy.md).
+    # 6a2/DRIFT.a2ml = repo-local append-only drift log (feedback_sessional_
+    # drift_detection.md + user_6a2_is_contractile_ought.md descriptive role).
+    evidence_sinks = [
+      {
+        kind   = 'verisimdb,
+        table  = "contractile_executions",
+        schema = "contractile_execution_v1",
+      },
+      {
+        kind        = 'drift_log,
+        path        = ".machine_readable/6a2/DRIFT.a2ml",
+        append_only = true,
+      },
+    ],
+
+    # Session-close hook — the "picked up sessionally" requirement.
+    # Re-execute, diff against the last ratification, surface expired
+    # variances, emit drift entries for new failures.
+    on_close = {
+      re_execute_all_intents = true,
+      diff_against_last_ratification = true,
+      emit_drift_entries_for_new_failures = true,
+      surface_expired_variances = true,
+    },
+
+    # -----------------------------------------------------------------
+    # Session-open hook — NEGOTIATION + RATIFICATION + ACCOUNTABILITY
+    # (user_contract_negotiation_and_accountability_pledge.md)
+    # (user_contractiles_agreed_at_session_start.md)
+    #
+    # Ratification is not passive acknowledgement; it is negotiation
+    # ending in an explicit accountability pledge from BOTH parties.
+    # Work cannot proceed before both pledges are on file.
+    # -----------------------------------------------------------------
+    on_open = {
+      # --- Context presentation (pre-negotiation) ---
+      render_summary = 'plain_language,    # metaphor-capture defense
+      include_drift_log_from_last_close = true,
+      include_active_variances = true,
+      include_recent_anchors = true,
+      anchor_lookback_weeks = 8,
+
+      # --- Negotiation phase (five mandatory inputs) ---
+      # AI must surface all five before the user is asked to ratify.
+      # "Yes, and …" — not "yes". Missing any of the five = the
+      # negotiation is incomplete and work cannot proceed.
+      negotiation = {
+        required = true,              # blank-cheque ratification refused
+
+        # The five inputs the AI must contribute to the negotiation.
+        # Each is a structured field the agent is required to populate,
+        # not optional prose. See user_contract_negotiation_and_
+        # accountability_pledge.md for the domain-language-rendering rule.
+        ai_required_inputs = [
+          'timeline_realism,           # "this will take X; not Y"
+          'industry_standards,         # WCAG, ISO, OWASP, GDPR, licensing …
+          'audience_feasibility,       # real addressable user set
+          'resulting_invariants,       # what must/trust/adjust entries follow
+          'ecosystem_dependencies,     # libs, licences, threat-model implications
+        ],
+
+        # User must actually engage with each input — not
+        # auto-approve. If user tries to skip ("just do it, I trust you")
+        # the system re-renders the obligations and requires the pledge.
+        user_engagement_required = true,
+        user_engagement_mode = 'per_input_response,
+
+        # The AI does the specification-form work. The user reviews the
+        # rendering in domain language and accepts / amends / pushes back.
+        # User never has to author Nickel schemas or decide on type
+        # specificity — that is the AI's translation responsibility,
+        # with auditable faithfulness.
+        specification_translation = {
+          ai_produces_spec_form = true,
+          user_reviews_in_domain_language = true,
+          schema_authoring_is_ai_responsibility = true,
+          translation_faithfulness_auditable = true,
+          # Failure mode this closes: user is forced to learn spec-theory
+          # (type refinement, Nickel contract grammar) to ratify a contract
+          # — which drives users away from ratification entirely.
+        },
+      },
+
+      # --- Accountability pledge (both parties, explicit) ---
+      # Not "I read it" — "I am answerable for this obligation".
+      # Both pledges are required before work proceeds; both are recorded.
+      accountability_pledge = {
+        required = true,
+        parties = [
+          {
+            role = 'user,
+            pledge = "I have reviewed the obligations as negotiated; I accept accountability for meeting the declared invariants and for the audience/timeline/standards consequences surfaced in negotiation.",
+            signature_required = true,
+          },
+          {
+            role = 'ai_agent,
+            pledge = "I will hold the user to the obligations as negotiated, including by surfacing drift at session close and refusing off-contract actions, even when the user is enthusiastic about them. If the user wishes to depart from the contract, I will require a variance or amendment, not silent acceptance.",
+            signature_required = true,
+            # Per user_contractile_is_contract_do_not_break.md —
+            # the AI is the holder of the line against enthusiasm drift.
+          },
+        ],
+        signed_record_destination = ".machine_readable/6a2/ratification-<session-id>.a2ml",
+        must_precede_work = true,
+      },
+
+      # --- Policy: ratification output ---
+      # The ratification record IS the negotiation transcript + the
+      # accountability pledge combined. One document; future-session
+      # ground-truth for "what was agreed, who is accountable".
+      ratification_record_shape = {
+        includes_negotiation_transcript = true,
+        includes_both_pledges = true,
+        signed = true,
+        dated = true,
+        session_id = 'required,
+        contract_hash = 'required,    # pins what was actually signed
+      },
+    },
+  },
+
+  # -------------------------------------------------------------------
+  # Failure-mode defenses — explicit cross-reference to the catalog
+  # (feedback_ai_failure_mode_catalog.md). New catalog entries that
+  # shift this verb's defenses must update this list, not narrative.
+  # -------------------------------------------------------------------
+  failure_mode_defenses = [
+    'A1_enthusiasm_capture,            # scope breach → drift log
+    'A2_metaphor_capture,              # render_summary = 'plain_language
+    'A3_allegory_drift,                # intents cite concrete obligations
+    'C1_scope_creep,                   # feature-adjacent change needs intent_id
+    'C3_helpfulness_inflation,         # changes without intent_id flagged
+    'C4_modernization_drift,           # upgrade cannot cite intent → drift
+    'D5_sycophancy,                    # ratification compares user framing vs contract
+    'F1_across_session_forgetting,     # on_open reads last-ratification record
+  ],
+}

--- a/.machine_readable/contractiles/intend/intend.manifest.a2ml
+++ b/.machine_readable/contractiles/intend/intend.manifest.a2ml
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MPL-2.0
+# intend.manifest.a2ml — Trident coherence manifest for the intend verb.
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Asserts: exactly three files constitute the intend trident; their
+# content-hashes are pinned here; cross-references round-trip; no
+# partial publication is permitted.
+#
+# The contractile CLI's `verify <verb>` subcommand MUST:
+#   1. Confirm all three listed files exist at the declared paths.
+#   2. Compute each file's sha256 and match against the pinned value.
+#   3. Follow each cross-reference and confirm the target file's
+#      reciprocal field points back.
+#   4. Refuse the dir (exit non-zero) if any of 1–3 fails.
+#
+# This forecloses the failure mode where an agent publishes an A2ML
+# declaration with no paired runner or K9 component — the trident is
+# atomically complete or it is invalid.
+
+---
+trident_version = "1.0.0"
+verb = "intend"
+semantics = "north-star (commitments + aspirations)"
+cardinality = "one per repo"
+
+## Files (three; exactly)
+
+[[files]]
+role = "declaration"
+path = "Intentfile.a2ml"
+sha256 = "pending-first-verify"   # populated on first `contractile verify intend`
+size_bytes = "pending-first-verify"
+
+[[files]]
+role = "runner"
+path = "intend.ncl"
+sha256 = "pending-first-verify"
+size_bytes = "pending-first-verify"
+
+[[files]]
+role = "k9_component"
+path = "intend.k9.ncl"
+sha256 = "pending-first-verify"
+size_bytes = "pending-first-verify"
+
+## Cross-references (must round-trip)
+
+[cross_refs]
+# Each runner/K9 component names its paired files; the CLI follows the
+# links and asserts reciprocity. Any dangling or mismatched reference
+# fails the verify gate.
+runner_paired_xfile   = "Intentfile.a2ml"
+k9_paired_xfile       = "../intend/Intentfile.a2ml"
+k9_paired_runner      = "../intend/intend.ncl"
+
+## Trident signing
+
+[signed_by]
+user    = "Jonathan D.A. Jewell"
+date    = "2026-04-18"
+context = "intend trident pilot — first Trident instance in the estate; template for the remaining 5 verbs (must/trust/bust/adjust/dust) and for the 14 template-copy dirs."
+
+## Change log
+
+[[history]]
+date = "2026-04-18"
+event = "trident-born"
+note = "intend/Intentfile.a2ml pre-existed (f380b62, lust absorption). This manifest + intend.k9.ncl complete the trident for the first time."
+
+[[history]]
+date = "2026-04-18"
+event = "negotiation-accountability-schema-landed"
+note = "intend.k9.ncl on_open hook extended: five negotiation inputs (timeline/standards/audience/invariants/dependencies), both-parties accountability pledge, plain-language-translation policy (AI authors spec form, user reviews in domain language). K9 metadata version bumped 1.0.0 → 2.0.0. Prerequisite for the adversarial Gemini+Copilot drift pilot; intend is the hardest verb (abstract north-star) so baking the full protocol here first means simpler verbs (trust, must) can inherit the template."

--- a/.machine_readable/contractiles/intend/intend.ncl
+++ b/.machine_readable/contractiles/intend/intend.ncl
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MPL-2.0
+# Intend — north-star runner (verb is `intend`, file is `Intentfile.a2ml`)
+#
+# Pairs with: Intentfile.a2ml (same directory)
+# Verb:       intend
+# Semantics:  Declares BOTH concrete committed next-actions ([[intents]]) and
+#             horizon aspirations ([[wishes]]). Not a gate — reports progress
+#             toward declared intents and lists wishes by horizon.
+#             Status progressions:
+#               intents: 'declared → 'in_progress → 'done | 'deferred | 'retired
+#               wishes:  'declared → 'in_progress → 'achieved | 'abandoned
+# CLI:        `contractile intend run`       → print status table (both sections)
+#             `contractile intend progress`  → diff declared-vs-observed (intents)
+#             `contractile intend horizon`   → group wishes by near/mid/far
+#
+# History:    Absorbed the deprecated `lust` contractile's [[wishes]] schema
+#             2026-04-18. `lust/` dir removed estate-wide.
+#
+# Anything else in this directory is human-only notes/archive; machines ignore.
+#
+# Base: ../_base.ncl provides pedigree_schema, run_defaults, probe_schema.
+# See: docs/CONTRACTILE-SPEC.adoc
+
+let base = import "../_base.ncl" in
+
+{
+  pedigree = base.pedigree_schema & {
+    contractile_verb = "intend",
+    semantics = "north-star (commitments + aspirations)",
+    security = {
+      leash = 'Kennel,
+      trust_level = "read-only reporting",
+      allow_network = false,
+      allow_filesystem_write = false,
+      allow_subprocess = true,      # probe commands may shell out (intents only; wishes never probe)
+    },
+    metadata = {
+      name = "intend-runner",
+      version = "2.0.0",
+      description = "Reports progress toward committed next-actions and lists horizon aspirations. Non-gating. Absorbed `lust` semantics 2026-04-18.",
+      paired_xfile = "Intentfile.a2ml",
+      author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+  },
+
+  schema = {
+    intents
+      | Array {
+          id | String,
+          description | String,
+          # TODO: migrate to base.probe_schema (structured probe) when CLI supports it
+          probe | String | optional,     # shell command that indicates done-ness
+          status | [| 'declared, 'in_progress, 'done, 'deferred, 'retired |] | default = 'declared,
+          notes | String | optional,
+          target_date | String | optional,
+        },
+    wishes
+      | Array {
+          id | String,
+          description | String,
+          horizon | [| 'near, 'mid, 'far |] | default = 'mid,
+          why | String | optional,
+          status | [| 'declared, 'in_progress, 'achieved, 'abandoned |] | default = 'declared,
+          notes | String | optional,
+        }
+      | optional,
+  },
+
+  # Runner behaviour — inherits from base.run_defaults.
+  # intend never blocks; it is a report only.
+  # emit_diff is intent-specific (declared vs observed probes).
+  # emit_grouped_by_horizon renders wishes grouped by near/mid/far.
+  run = base.run_defaults & {
+    on_pass = "continue",
+    on_any_fail = "continue",         # never blocks; it's a report
+    report_format = "a2ml",
+    emit_summary = true,
+    emit_diff = true,                 # declared vs observed (intents)
+    emit_grouped_by_horizon = true,   # wishes grouped by horizon (absorbed from lust)
+  },
+}

--- a/.machine_readable/contractiles/must/Mustfile.a2ml
+++ b/.machine_readable/contractiles/must/Mustfile.a2ml
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: MPL-2.0
+# Mustfile — Physical state contract for VeriSimDB
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# What MUST be true about this repository. Hard requirements.
+# Pairs with: must.ncl (same directory)
+# Run with: contractile must run
+# Fix with: contractile must fix (where deterministic fix exists)
+
+@abstract:
+Physical-state invariants for VeriSimDB — the cross-modal (octad) entity
+consistency engine. Rust core + Elixir/OTP orchestration + ReScript VQL.
+These are hard requirements: CI and pre-commit hooks fail if any check fails.
+@end
+
+## Workspace Structure
+
+### cargo-workspace-present
+- description: Root Cargo workspace manifest must exist
+- run: test -f Cargo.toml
+- severity: critical
+
+### rust-core-present
+- description: Rust core crate directory must exist
+- run: test -d rust-core
+- severity: critical
+
+### verisim-api-crate
+- description: verisim-api HTTP server crate must exist
+- run: test -d rust-core/verisim-api
+- severity: critical
+
+### verisim-octad-crate
+- description: verisim-octad unified-entity crate must exist
+- run: test -d rust-core/verisim-octad
+- severity: critical
+
+### elixir-mix-present
+- description: Elixir orchestration mix.exs must exist
+- run: test -f elixir-orchestration/mix.exs
+- severity: critical
+
+### elixir-lib-present
+- description: Elixir VeriSim library tree must exist
+- run: test -d elixir-orchestration/lib/verisim
+- severity: critical
+
+## File Presence
+
+### license-present
+- description: LICENSE file must exist
+- run: test -f LICENSE
+- severity: critical
+
+### readme-present
+- description: README.adoc must exist
+- run: test -f README.adoc
+- severity: critical
+
+### security-policy
+- description: SECURITY.md must exist
+- run: test -f SECURITY.md
+- severity: critical
+
+### ai-manifest
+- description: 0-AI-MANIFEST.a2ml must exist
+- run: test -f 0-AI-MANIFEST.a2ml
+- severity: high
+
+### known-issues-doc
+- description: KNOWN-ISSUES.adoc must exist (honest-gaps register)
+- run: test -f KNOWN-ISSUES.adoc
+- severity: warning
+
+### editorconfig
+- description: .editorconfig must exist
+- run: test -f .editorconfig
+- severity: warning
+
+## VQL (VeriSim Query Language)
+
+### vql-rescript-parser
+- description: ReScript VQL parser source must exist
+- run: test -d src/vql
+- severity: critical
+
+### vql-elixir-bridge
+- description: Elixir VQL bridge module must exist
+- run: test -f elixir-orchestration/lib/verisim/query/vql_bridge.ex
+- severity: high
+
+### vql-examples-present
+- description: At least one .vql example/fixture must exist
+- run: test -n "$(find . -name '*.vql' -not -path '*/.git/*' 2>/dev/null)"
+- severity: warning
+
+## Container Policy
+
+### containerfile-present
+- description: container/Containerfile must exist (Podman build front door)
+- run: test -f container/Containerfile
+- severity: high
+
+### no-dockerfile-outside-fuzz
+- description: No Dockerfile outside the .clusterfuzzlite OSS-Fuzz harness (use Containerfile + Podman)
+- run: test -z "$(find . -name 'Dockerfile' -not -path '*/.clusterfuzzlite/*' -not -path '*/.git/*' 2>/dev/null)"
+- severity: warning
+
+## Language Policy
+
+### no-python
+- description: No Python files (policy: use Rust/Elixir/ReScript; Julia for data processing)
+- run: test -z "$(find . -name '*.py' -not -path '*/.git/*' -not -path '*/deps/*' 2>/dev/null)"
+- severity: critical
+
+### no-go
+- description: No Go files (policy: use Rust)
+- run: test -z "$(find . -name '*.go' -not -path '*/.git/*' -not -path '*/deps/*' 2>/dev/null)"
+- severity: warning
+
+## License Compliance
+
+### no-agpl
+- description: No AGPL-3.0 headers in source (workspace normalised to MPL-2.0, closes #82)
+- run: test -z "$(grep -rlE 'AGPL-3\.0' --include='*.rs' --include='*.ex' --include='*.exs' --include='*.idr' --include='*.zig' . 2>/dev/null)"
+- severity: critical
+- notes: Mirrors the `just license-check` recipe.
+
+## Dangerous Patterns
+
+### no-believe-me
+- description: No believe_me in Idris2 ABI code (0-believe_me invariant)
+- run: test -z "$(find . -name '*.idr' -not -path '*/.git/*' -exec grep -l 'believe_me' {} \; 2>/dev/null)"
+- severity: critical

--- a/.machine_readable/contractiles/must/must.ncl
+++ b/.machine_readable/contractiles/must/must.ncl
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MPL-2.0
+# Must — invariants runner
+#
+# Pairs with: Mustfile.a2ml (same directory)
+# Verb:       must (invariant assertion)
+# Semantics:  every check is a hard gate. A single failure blocks merge.
+# CLI:        `contractile must run` → reads Mustfile.a2ml, evaluates each check,
+#             emits pass/fail verdict per item, exits non-zero if any failed.
+#
+# This file is the *schema + runner* that the `contractile` CLI (at
+# /var/mnt/eclipse/repos/reposystem/contractiles/cli/) loads alongside
+# Mustfile.a2ml. Anything else in this directory is human-only notes/archive
+# and MUST be ignored by machines.
+#
+# Base: ../_base.ncl provides pedigree_schema, run_defaults, probe_schema.
+# See: docs/CONTRACTILE-SPEC.adoc
+
+let base = import "../_base.ncl" in
+
+{
+  pedigree = base.pedigree_schema & {
+    contractile_verb = "must",
+    semantics = "invariant",
+    security = {
+      leash = 'Kennel,
+      trust_level = "read-only verification",
+      allow_network = false,
+      allow_filesystem_write = false,
+      allow_subprocess = true,    # verification probes may shell out (e.g. grep, test -f)
+    },
+    metadata = {
+      name = "must-runner",
+      version = "1.0.0",
+      description = "Evaluates every invariant in the adjacent Mustfile.a2ml as a hard gate.",
+      paired_xfile = "Mustfile.a2ml",
+      author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+  },
+
+  # Contract schema — the shape every Mustfile.a2ml must satisfy.
+  # Used by `contractile must typecheck Mustfile.a2ml`.
+  schema = {
+    invariants
+      | Array {
+          id | String,
+          description | String,
+          # TODO: migrate to base.probe_schema (structured probe) when CLI supports it
+          probe | String,                          # shell command; exit 0 = pass
+          # status_core values: 'declared, 'verified, 'failing
+          status | [| 'declared, 'verified, 'failing |] | default = 'declared,
+          severity | [| 'critical, 'high, 'medium |] | default = 'critical,
+          notes | String | optional,
+          fix | String | optional,
+        },
+  },
+
+  # Runner behaviour — consumed by the contractile CLI dispatcher.
+  # Inherits from base.run_defaults; on_any_fail is the hard-gate default.
+  run = base.run_defaults & {
+    on_any_fail = "exit-nonzero",     # hard gate
+    report_format = "a2ml",           # emit a2ml report, not json
+    emit_summary = true,
+  },
+}

--- a/.machine_readable/contractiles/trust/Trustfile.a2ml
+++ b/.machine_readable/contractiles/trust/Trustfile.a2ml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MPL-2.0
+# Trustfile — Integrity, provenance and safe-hacking contract for VeriSimDB
+# Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+#
+# Security + provenance verifications PLUS an authorised safe-hacking section
+# scoped strictly to this repo. Hard gate on any verification failure.
+# Pairs with: trust.ncl (same directory)
+# Run with:  contractile trust verify   (read-only verifications)
+#            contractile trust probe    (authorised safe-hacking probes)
+
+@abstract:
+Integrity and provenance invariants for VeriSimDB, plus a declared
+safe-hacking section. Verifications are read-only and offline by default;
+safe-hacking probes are scoped to this-repo-only (cargo fuzz / property
+tests) and never touch external systems. All hard-gating.
+@end
+
+## License & SPDX Integrity
+
+### no-agpl-headers
+- description: No AGPL-3.0 license headers anywhere in source
+- run: test -z "$(grep -rlE 'AGPL-3\.0' --include='*.rs' --include='*.ex' --include='*.exs' --include='*.idr' --include='*.zig' --include='*.yml' . 2>/dev/null)"
+- severity: critical
+
+### license-file-mpl2
+- description: LICENSE body declares MPL-2.0 (workspace normalised, closes #82 / PR #101)
+- run: grep -q 'Mozilla Public License' LICENSE
+- severity: critical
+
+### spdx-on-rust
+- description: Rust crate roots carry an SPDX-License-Identifier header
+- run: test -z "$(find rust-core -name 'lib.rs' -o -name 'main.rs' 2>/dev/null | head -1 | xargs -r grep -L 'SPDX-License-Identifier' 2>/dev/null)"
+- severity: high
+- notes: Spot-check on crate entry points; full sweep runs in CI.
+
+## Supply-Chain Provenance
+
+### cargo-lock-committed
+- description: Cargo.lock is committed (reproducible Rust dependency graph)
+- run: test -f Cargo.lock
+- severity: high
+
+### deny-toml-present
+- description: cargo-deny policy (deny.toml) present for dependency auditing
+- run: test -f deny.toml
+- severity: medium
+
+### stapeln-manifest-present
+- description: stapeln/cerro-torre supply-chain manifest present
+- run: test -f stapeln.toml || test -f container/manifest.toml
+- severity: medium
+- notes: .ctp bundle provenance + attestations for verified container deploy.
+
+### gatekeeper-policy-present
+- description: svalinn edge-gateway policy present (auth, rate limits, trust)
+- run: test -f container/.gatekeeper.yaml
+- severity: low
+
+## Secret Hygiene
+
+### no-env-files
+- description: No committed .env secret files
+- run: test ! -f .env && test ! -f elixir-orchestration/.env
+- severity: critical
+
+### no-beam-cookie
+- description: No Erlang/BEAM cookie committed
+- run: test -z "$(find . -name '.erlang.cookie' -not -path '*/.git/*' 2>/dev/null)"
+- severity: critical
+
+## Safe Hacking (this-repo-only)
+
+### cargo-fuzz-harness-present
+- description: cargo-fuzz harness directory exists for in-repo fuzzing
+- run: test -d fuzz || test -d rust-core/fuzz
+- severity: medium
+- class: fuzz
+- scope: this-repo-only
+- expected_outcome: probe_finds_no_issue
+- notes: Authorised offensive probe target; runs `cargo fuzz` against repo-local crates only.
+
+### vql-property-tests-present
+- description: VQL property-test suite exists (proptest/StreamData over the parser)
+- run: test -f elixir-orchestration/test/verisim/property/vql_bridge_props_test.exs
+- severity: low
+- class: property_test
+- scope: this-repo-only
+- expected_outcome: probe_finds_no_issue

--- a/.machine_readable/contractiles/trust/trust.ncl
+++ b/.machine_readable/contractiles/trust/trust.ncl
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MPL-2.0
+# Trust — security + safe-hacking runner
+#
+# Pairs with: Trustfile.a2ml (same directory)
+# Verb:       trust
+# Semantics:  integrity / provenance / security verification PLUS a declared
+#             "safe hacking + testing" section — authorised offensive probes
+#             (pen-test harness runs, chaos-engineering probes) scoped to the
+#             repo under test, NEVER touching external systems.
+# CLI:        `contractile trust verify` → run all verifications (read-only)
+#             `contractile trust probe`  → run declared safe-hacking probes
+#
+# Anything else in this directory is human-only notes/archive; machines ignore.
+#
+# Base: ../_base.ncl provides pedigree_schema, run_defaults, probe_schema.
+# See: docs/CONTRACTILE-SPEC.adoc
+
+let base = import "../_base.ncl" in
+
+{
+  pedigree = base.pedigree_schema & {
+    contractile_verb = "trust",
+    semantics = "security + provenance + safe-hacking",
+    security = {
+      leash = 'Kennel,
+      trust_level = "verification + authorised-probe",
+      allow_network = false,            # verifications are offline by default
+      allow_filesystem_write = false,   # trust writes NOTHING
+      allow_subprocess = true,
+      authorised_probes_only = true,    # probe section must explicitly list allowed targets
+    },
+    metadata = {
+      name = "trust-runner",
+      version = "1.0.0",
+      description = "Security + provenance verifications plus authorised safe-hacking probes. All probes are scoped to the repo under test; never hits external systems.",
+      paired_xfile = "Trustfile.a2ml",
+      author = "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",
+    },
+  },
+
+  schema = {
+    verifications
+      | Array {
+          id | String,
+          description | String,
+          # TODO: migrate to base.probe_schema (structured probe) when CLI supports it
+          probe | String,                 # read-only; exit 0 = pass
+          # status_core values: 'declared, 'verified, 'failing
+          status | [| 'declared, 'verified, 'failing |] | default = 'declared,
+          # trust uses all four severity levels (from base.severity_core)
+          severity | [| 'critical, 'high, 'medium, 'low |] | default = 'high,
+          notes | String | optional,
+        },
+
+    # Safe-hacking + testing section (added 2026-04-17 per user direction).
+    # Each probe here is an ACTIVELY EXECUTED test — fuzz runs, chaos probes,
+    # auth-bypass attempts, injection tests. All scoped to the current repo.
+    safe_hacking
+      | {
+          scope | String,                 # e.g. "this-repo-only" / "localhost"
+          allowed_probe_classes
+            | Array [| 'fuzz, 'property_test, 'chaos, 'auth_bypass, 'injection, 'timing |]
+            | default = [],
+          probes
+            | Array {
+                id | String,
+                class | [| 'fuzz, 'property_test, 'chaos, 'auth_bypass, 'injection, 'timing |],
+                description | String,
+                # TODO: migrate to base.probe_schema (structured probe) when CLI supports it
+                probe | String,             # command to run the probe
+                expected_outcome | [| 'probe_blocks_attempt, 'probe_finds_no_issue |],
+                timeout_seconds | Number | default = 300,
+                notes | String | optional,
+              }
+            | default = [],
+        }
+      | default = { scope = "this-repo-only", allowed_probe_classes = [], probes = [] },
+  },
+
+  # Runner behaviour — inherits from base.run_defaults.
+  # trust has an extra field for unexpected safe-hacking outcomes.
+  run = base.run_defaults & {
+    on_any_fail = "exit-nonzero",       # hard gate on verifications
+    safe_hacking_on_unexpected_outcome = "exit-nonzero",  # probe found what it shouldn't = block
+    report_format = "a2ml",
+    emit_summary = true,
+  },
+}


### PR DESCRIPTION
## Summary

Fills the machine-readable gap left by #114. That PR delivered the superior `6a2/`, populated `bot_directives/*.a2ml`, and `svc/self-validating/` — but did **not** migrate contractiles into `.machine_readable/` or add an anchor. verisimdb `main` still had only the old root-level `contractiles/{must,trust,dust}` (3 verbs, extensionless, no INDEX/tridents).

This PR is **purely additive** — it does not touch #114's `6a2`, `bot_directives`, or `svc/self-validating` work.

### Adds under `.machine_readable/contractiles/`
- `INDEX.a2ml` — 6-verb registry (`must/trust/bust/adjust/dust/intend` + the k9 exception)
- `_base.ncl` — shared Nickel base for verb runners
- All six verbs: `{Verb}file.a2ml` + `{verb}.ncl` runner
- `adjust` + `intend`: full trident (`.k9.ncl` trust-tier binding + `.manifest.a2ml`)

### Adds
- `.machine_readable/anchors/ANCHOR.a2ml` — canonical authority / recalibration trigger

### verisimdb-specific adaptations
- **k9 import paths** point at `.machine_readable/svc/self-validating/` (verisimdb's k9 home after #114's `svc/k9` → `svc/self-validating` rename): `../../svc/self-validating/template-hunt.k9.ncl` in the verb `.k9.ncl` bindings, `../svc/self-validating/` in `INDEX.a2ml`.
- **Dustfile**: dropped two now-stale `rsr-template-residue` entries — #114 de-templatized the 6a2 set; `ECOSYSTEM.a2ml` + `META.a2ml` verified clean on rebuild.

## Validation (real, not eyeballed)

- `nickel 1.16.0 typecheck` **PASS** on all 7 pure `.ncl` (`must/trust/bust/adjust/dust/intend` runners + `_base.ncl`).
- The 2 verb `.k9.ncl` files are plain Nickel importing the `K9!`-sigil template; nickel resolves the import **path** correctly (errors only on the template's `K9!` line 1, which is the k9 CLI's domain) — consistent with the merged sibling repos.
- All `.a2ml` carry SPDX headers; content verified verisimdb-scoped (VQL Playground, PanLL dashboard, `verisim-drift`/`verisim-normalizer`, the six drift types) — no wrong-project leakage; language-policy probes match Rust/Elixir/ReScript.

## Note for reviewer — estate-wide latent finding

The verb `.k9.ncl` bindings reference `base_k9.pedigree_schema`, but the `svc/self-validating/template-hunt.k9.ncl` template exports `pedigree` (concrete), not `pedigree_schema`. This mismatch is present in the merged sibling repos too (same canonical source) and only surfaces when a k9 CLI evaluates these k9-dialect files. Flagged for the k9-CLI owner; not a blocker here (parity with merged repos).

## Test plan

- [ ] `nickel typecheck` green on the 7 pure `.ncl` (reproduce locally)
- [ ] `INDEX.a2ml` verb list matches the on-disk tree
- [ ] No `6a2/`, `bot_directives/`, or `svc/` files modified (purely additive)

https://claude.ai/code/session_01PhqGcxCqkMdJtR6NWq56Hx

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhqGcxCqkMdJtR6NWq56Hx)_