### PR TITLE
feat(api): S4 learning-loop server side + /api/v1 prefix mount + GHCR publish

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MPL-2.0
+#
+# Publish the verisim-api container image to GHCR.
+#
+# Downstream contract: echidna's S4 loop-closure CI (see
+# echidna/docs/handover/S4-LOOP-CLOSURE-RUNBOOK.md) waits on
+# ghcr.io/hyperpolymath/verisimdb-api existing as a pullable service
+# image. Tags published: `latest` (main HEAD) + the 12-char commit SHA.
+name: ghcr-publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rust-core/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "container/**"
+      - ".github/workflows/ghcr-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/hyperpolymath/verisimdb-api
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+
+      - name: Build image (Podman)
+        run: |
+          SHORT_SHA="${GITHUB_SHA::12}"
+          podman build \
+            -t "$IMAGE:latest" \
+            -t "$IMAGE:$SHORT_SHA" \
+            -f container/Containerfile .
+
+      - name: Smoke-test image
+        run: |
+          podman run -d --name verisim-smoke -p 8080:8080 \
+            -e VERISIM_ENABLE_IPV4=true "$IMAGE:latest"
+          for i in $(seq 1 30); do
+            curl -sf http://127.0.0.1:8080/health >/dev/null && break
+            sleep 2
+          done
+          curl -sf http://127.0.0.1:8080/health
+          # The S4 endpoints must answer at the documented /api/v1 prefix.
+          curl -sf "http://127.0.0.1:8080/api/v1/mv_prover_success_by_class?class=smoke" >/dev/null
+          podman rm -f verisim-smoke
+
+      - name: Push to GHCR
+        if: github.event_name != 'pull_request'
+        run: |
+          SHORT_SHA="${GITHUB_SHA::12}"
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+          podman push "$IMAGE:latest"
+          podman push "$IMAGE:$SHORT_SHA"

--- a/rust-core/verisim-api/src/lib.rs
+++ b/rust-core/verisim-api/src/lib.rs
@@ -2492,8 +2492,7 @@ mod tests {
             let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
                 .await
                 .unwrap();
-            let rows: Vec<proof_attempts::ProofAttempt> =
-                serde_json::from_slice(&body).unwrap();
+            let rows: Vec<proof_attempts::ProofAttempt> = serde_json::from_slice(&body).unwrap();
             assert_eq!(rows.len(), 2, "both attempts visible at {prefix}");
             assert_eq!(rows[0].outcome, "failure", "most recent first");
         }
@@ -2514,8 +2513,7 @@ mod tests {
         let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
             .await
             .unwrap();
-        let rows: Vec<proof_attempts::ProverSuccessRow> =
-            serde_json::from_slice(&body).unwrap();
+        let rows: Vec<proof_attempts::ProverSuccessRow> = serde_json::from_slice(&body).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].prover, "z3");
         assert_eq!(rows[0].total_attempts, 4);
@@ -2535,7 +2533,10 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         // Missing required query parameters are 400s.
-        for uri in ["/api/v1/proof_attempts", "/api/v1/mv_prover_success_by_class"] {
+        for uri in [
+            "/api/v1/proof_attempts",
+            "/api/v1/mv_prover_success_by_class",
+        ] {
             let response = app
                 .clone()
                 .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())

--- a/rust-core/verisim-api/src/lib.rs
+++ b/rust-core/verisim-api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod auth;
 pub mod federation;
 pub mod graphql;
 pub mod grpc;
+pub mod proof_attempts;
 pub mod rbac;
 pub mod transaction;
 pub mod vql;
@@ -507,6 +508,7 @@ pub struct AppState {
     pub circuit_registry: Arc<CircuitRegistry>,
     pub federation: federation::FederationState,
     pub auth: auth::AuthState,
+    pub proof_attempts: Arc<proof_attempts::ProofAttemptStore>,
     pub config: ApiConfig,
 }
 
@@ -682,6 +684,15 @@ impl AppState {
         let auth = auth::AuthState::default();
         let circuit_registry = Arc::new(CircuitRegistry::new());
 
+        // --- S4 proof-attempt row store (ECHIDNA learning loop) ---
+        #[cfg(feature = "persistent")]
+        let proof_attempts = Arc::new(
+            proof_attempts::ProofAttemptStore::with_persistence(&persist_dir)
+                .map_err(|e| ApiError::Internal(format!("proof_attempts store: {e}")))?,
+        );
+        #[cfg(not(feature = "persistent"))]
+        let proof_attempts = Arc::new(proof_attempts::ProofAttemptStore::in_memory());
+
         Ok(Self {
             start_time: std::time::Instant::now(),
             octad_store,
@@ -694,6 +705,7 @@ impl AppState {
             circuit_registry,
             federation,
             auth,
+            proof_attempts,
             config,
         })
     }
@@ -785,6 +797,15 @@ pub fn build_router(state: AppState) -> Router {
         .route("/spatial/search/nearest", post(spatial_nearest_handler))
         // VQL text query endpoint (used by verisim-repl)
         .route("/vql/execute", post(vql::vql_execute_handler))
+        // S4 learning loop — ECHIDNA proof attempts (see proof_attempts module docs)
+        .route(
+            "/proof_attempts",
+            get(proof_attempts::list_handler).post(proof_attempts::record_handler),
+        )
+        .route(
+            "/mv_prover_success_by_class",
+            get(proof_attempts::success_by_class_handler),
+        )
         // Authentication middleware layer
         .layer(axum_middleware::from_fn_with_state(
             auth_state,
@@ -795,6 +816,22 @@ pub fn build_router(state: AppState) -> Router {
         .merge(graphql::graphql_router(state))
         // Federation endpoints (separate state)
         .merge(federation_routes)
+}
+
+/// Mount the API router at both the root and under `version_prefix`.
+///
+/// Historically `serve()` mounted everything at the root and the configured
+/// `version_prefix` ("/api/v1") was never applied, so documented prefixed
+/// paths (and every `/api/v1/…` call from ECHIDNA's verisim_bridge) 404'd.
+/// Root mounting is kept for backwards compatibility with consumers that
+/// grew up against the unprefixed paths (verisim-repl, local tooling);
+/// the nested mount makes the documented contract real.
+pub fn mount_with_prefix(api: Router, prefix: &str) -> Router {
+    let prefix = prefix.trim_end_matches('/');
+    if prefix.is_empty() || !prefix.starts_with('/') {
+        return api;
+    }
+    Router::new().nest(prefix, api.clone()).merge(api)
 }
 
 /// Health check handler — verifies drift detector status and reports degraded when critical
@@ -1928,7 +1965,7 @@ pub async fn serve(config: ApiConfig) -> Result<(), std::io::Error> {
     let octad_store = state.octad_store.clone();
 
     // Build HTTP router with hardening middleware
-    let app = build_router(state.clone())
+    let app = mount_with_prefix(build_router(state.clone()), &config.version_prefix)
         .layer(axum::extract::DefaultBodyLimit::max(config.max_body_size));
 
     // Start HTTP server
@@ -2013,7 +2050,7 @@ pub async fn serve_tls(
         .map_err(|e| std::io::Error::other(e.to_string()))?;
 
     let octad_store = state.octad_store.clone();
-    let app = build_router(state);
+    let app = mount_with_prefix(build_router(state), &config.version_prefix);
 
     let addr = format!("{}:{}", config.host, config.port);
     info!(addr = %addr, cert = %cert_path, "Starting VeriSimDB API server with TLS");
@@ -2387,6 +2424,125 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// One proof-attempt JSON body in exactly the shape ECHIDNA posts.
+    fn s4_attempt_json(obligation_id: &str, class: &str, outcome: &str) -> String {
+        serde_json::json!({
+            "attempt_id": format!("test-{}-{}", obligation_id, outcome),
+            "obligation_id": obligation_id,
+            "repo": "hyperpolymath/echidna",
+            "file": "tests/s4_loop_closure.rs",
+            "claim": "true",
+            "obligation_class": class,
+            "prover_used": "z3",
+            "outcome": outcome,
+            "duration_ms": 1,
+            "confidence": if outcome == "success" { 1.0 } else { 0.0 },
+            "parent_attempt_id": null,
+            "strategy_tag": "test",
+            "started_at": "2026-06-11T00:00:00Z",
+            "completed_at": "2026-06-11T00:00:01Z",
+            "prover_output": "",
+            "error_message": null
+        })
+        .to_string()
+    }
+
+    /// Full S4 loop over the wire, at both the prefixed (/api/v1, the
+    /// ECHIDNA contract) and unprefixed (back-compat) mounts:
+    /// record → list by obligation_id → mv_prover_success_by_class.
+    #[tokio::test]
+    async fn test_s4_proof_attempts_loop() {
+        let state = create_test_state().await;
+        let app = mount_with_prefix(build_router(state), "/api/v1");
+
+        for (prefix, obligation) in [("/api/v1", "goal-prefixed"), ("", "goal-root")] {
+            // Record two attempts (one success, one failure).
+            for outcome in ["success", "failure"] {
+                let response = app
+                    .clone()
+                    .oneshot(
+                        Request::builder()
+                            .method("POST")
+                            .uri(format!("{prefix}/proof_attempts"))
+                            .header("content-type", "application/json")
+                            .body(Body::from(s4_attempt_json(obligation, "s4-test", outcome)))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::CREATED, "POST at {prefix}");
+            }
+
+            // Read back by obligation_id — most recent first.
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(format!(
+                            "{prefix}/proof_attempts?obligation_id={obligation}&limit=50"
+                        ))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+                .await
+                .unwrap();
+            let rows: Vec<proof_attempts::ProofAttempt> =
+                serde_json::from_slice(&body).unwrap();
+            assert_eq!(rows.len(), 2, "both attempts visible at {prefix}");
+            assert_eq!(rows[0].outcome, "failure", "most recent first");
+        }
+
+        // Aggregate over everything recorded above: 4 attempts in class
+        // s4-test for z3, half successful.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/mv_prover_success_by_class?class=s4-test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let rows: Vec<proof_attempts::ProverSuccessRow> =
+            serde_json::from_slice(&body).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].prover, "z3");
+        assert_eq!(rows[0].total_attempts, 4);
+        assert!((rows[0].success_rate - 0.5).abs() < f32::EPSILON);
+
+        // Unknown class and unknown obligation are empty 200s, not 404s.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/mv_prover_success_by_class?class=no-such-class")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Missing required query parameters are 400s.
+        for uri in ["/api/v1/proof_attempts", "/api/v1/mv_prover_success_by_class"] {
+            let response = app
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+        }
     }
 
     #[tokio::test]

--- a/rust-core/verisim-api/src/proof_attempts.rs
+++ b/rust-core/verisim-api/src/proof_attempts.rs
@@ -201,7 +201,10 @@ impl ProofAttemptStore {
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut counts: HashMap<String, (u32, u32)> = HashMap::new();
-        for attempt in rows.iter().filter(|a| a.obligation_class == obligation_class) {
+        for attempt in rows
+            .iter()
+            .filter(|a| a.obligation_class == obligation_class)
+        {
             let entry = counts.entry(attempt.prover_used.clone()).or_insert((0, 0));
             entry.1 += 1;
             if attempt.outcome == "success" {
@@ -237,11 +240,7 @@ impl ProofAttemptStore {
 // ── HTTP handlers ────────────────────────────────────────────────────────
 
 fn error_json(status: StatusCode, message: impl Into<String>) -> Response {
-    (
-        status,
-        Json(serde_json::json!({ "error": message.into() })),
-    )
-        .into_response()
+    (status, Json(serde_json::json!({ "error": message.into() }))).into_response()
 }
 
 /// `POST /proof_attempts` — record one attempt, 201 + `{"attempt_id": …}`.
@@ -342,7 +341,9 @@ mod tests {
         let second = attempt("goal-1", "c", "z3", "success");
         store.record(first.clone()).unwrap();
         store.record(second.clone()).unwrap();
-        store.record(attempt("goal-2", "c", "z3", "success")).unwrap();
+        store
+            .record(attempt("goal-2", "c", "z3", "success"))
+            .unwrap();
 
         let rows = store.by_obligation("goal-1", 50);
         assert_eq!(rows.len(), 2);
@@ -355,7 +356,9 @@ mod tests {
     fn limit_caps_results() {
         let store = ProofAttemptStore::in_memory();
         for _ in 0..10 {
-            store.record(attempt("goal-cap", "c", "z3", "success")).unwrap();
+            store
+                .record(attempt("goal-cap", "c", "z3", "success"))
+                .unwrap();
         }
         assert_eq!(store.by_obligation("goal-cap", 3).len(), 3);
     }
@@ -363,11 +366,21 @@ mod tests {
     #[test]
     fn success_rate_aggregation() {
         let store = ProofAttemptStore::in_memory();
-        store.record(attempt("g1", "linearity", "z3", "success")).unwrap();
-        store.record(attempt("g2", "linearity", "z3", "success")).unwrap();
-        store.record(attempt("g3", "linearity", "z3", "failure")).unwrap();
-        store.record(attempt("g4", "linearity", "coq", "timeout")).unwrap();
-        store.record(attempt("g5", "termination", "coq", "success")).unwrap();
+        store
+            .record(attempt("g1", "linearity", "z3", "success"))
+            .unwrap();
+        store
+            .record(attempt("g2", "linearity", "z3", "success"))
+            .unwrap();
+        store
+            .record(attempt("g3", "linearity", "z3", "failure"))
+            .unwrap();
+        store
+            .record(attempt("g4", "linearity", "coq", "timeout"))
+            .unwrap();
+        store
+            .record(attempt("g5", "termination", "coq", "success"))
+            .unwrap();
 
         let rows = store.success_by_class("linearity");
         assert_eq!(rows.len(), 2);
@@ -378,9 +391,7 @@ mod tests {
         assert_eq!(rows[1].prover, "z3");
         assert_eq!(rows[1].total_attempts, 3);
         assert!((rows[1].success_rate - 2.0 / 3.0).abs() < f32::EPSILON);
-        assert!(rows
-            .iter()
-            .all(|r| (0.0..=1.0).contains(&r.success_rate)));
+        assert!(rows.iter().all(|r| (0.0..=1.0).contains(&r.success_rate)));
         assert!(store.success_by_class("no-such-class").is_empty());
     }
 
@@ -412,8 +423,12 @@ mod tests {
 
         {
             let store = ProofAttemptStore::with_persistence(&dir).unwrap();
-            store.record(attempt("g-persist", "c", "lean", "success")).unwrap();
-            store.record(attempt("g-persist", "c", "lean", "failure")).unwrap();
+            store
+                .record(attempt("g-persist", "c", "lean", "success"))
+                .unwrap();
+            store
+                .record(attempt("g-persist", "c", "lean", "failure"))
+                .unwrap();
         }
 
         // Reopen: rows must come back in insertion order.
@@ -421,7 +436,10 @@ mod tests {
         assert_eq!(reopened.len(), 2);
         let rows = reopened.by_obligation("g-persist", 50);
         assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].outcome, "failure", "most recent first survives reload");
+        assert_eq!(
+            rows[0].outcome, "failure",
+            "most recent first survives reload"
+        );
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/rust-core/verisim-api/src/proof_attempts.rs
+++ b/rust-core/verisim-api/src/proof_attempts.rs
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Proof-attempt row store + the S4 learning-loop HTTP surface.
+//!
+//! ECHIDNA's dispatcher (`echidna/src/rust/verisim_bridge.rs`) writes one row
+//! per prover dispatch exit and reads two query shapes back:
+//!
+//! ```text
+//! POST /api/v1/proof_attempts                              record one attempt
+//! GET  /api/v1/proof_attempts?obligation_id={h}&limit={n}  attempts for a goal,
+//!                                                          most recent first
+//! GET  /api/v1/mv_prover_success_by_class?class={c}        per-prover success
+//!                                                          aggregate for a class
+//! ```
+//!
+//! The aggregate endpoint keeps its ClickHouse-era name (`mv_…`) because the
+//! client contract is the path string, not the storage engine; here the
+//! "materialised view" is computed on demand over the row store. Hypatia's H3
+//! proof-strategy rule reads the same endpoint, closing the loop:
+//! attempt → row → aggregate → strategy recommendation → next attempt.
+//!
+//! Storage: in-memory `Vec` behind an `RwLock`, with optional JSONL
+//! persistence (one row per line, append-on-record, loaded at startup) when
+//! the server runs with a persistence directory. Aggregations scan the rows;
+//! at the write rates of a proof dispatcher (hundreds of rows per CI run)
+//! this stays far below any threshold where an indexed engine would matter.
+
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::AppState;
+
+/// A single proof attempt, exactly mirroring the JSON body ECHIDNA posts.
+/// Field names are snake_case; prover/outcome are lowercase strings
+/// ("coq", "lean", …, "success", "timeout", "failure", "unknown").
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProofAttempt {
+    /// UUID v4 unique to this attempt.
+    pub attempt_id: String,
+    /// Stable hash of (repo, file, claim) — groups retries of one obligation.
+    pub obligation_id: String,
+    /// Repository identifier, e.g. "hyperpolymath/echidna".
+    pub repo: String,
+    /// File path within the repo.
+    pub file: String,
+    /// Human-readable obligation text.
+    pub claim: String,
+    /// Obligation class for strategy lookup, e.g. "linearity", "termination".
+    pub obligation_class: String,
+    /// Prover used ("coq", "lean", "z3", …).
+    pub prover_used: String,
+    /// Outcome ("success", "timeout", "failure", "unknown").
+    pub outcome: String,
+    pub duration_ms: u64,
+    /// Confidence score in [0.0, 1.0].
+    pub confidence: f32,
+    /// Prior attempt on the same obligation (for retries).
+    pub parent_attempt_id: Option<String>,
+    /// Strategy used, e.g. "portfolio", "gnn-guided", "manual", "retry".
+    pub strategy_tag: String,
+    /// ISO-8601 UTC timestamp when the attempt started.
+    pub started_at: String,
+    /// ISO-8601 UTC timestamp when the attempt completed.
+    pub completed_at: String,
+    /// Truncated prover stdout/stderr.
+    pub prover_output: String,
+    /// Error message if outcome != success.
+    pub error_message: Option<String>,
+}
+
+/// One row of the per-class aggregate. Matches the shape
+/// `[{"prover": "z3", "success_rate": 0.85, "total_attempts": 42}, …]`
+/// that `verisim_bridge::query_prover_success_by_class` deserialises.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProverSuccessRow {
+    pub prover: String,
+    pub success_rate: f32,
+    pub total_attempts: u32,
+}
+
+/// Row store for proof attempts: in-memory with optional JSONL persistence.
+pub struct ProofAttemptStore {
+    rows: RwLock<Vec<ProofAttempt>>,
+    persist_path: Option<PathBuf>,
+}
+
+impl ProofAttemptStore {
+    /// Purely in-memory store (default build).
+    pub fn in_memory() -> Self {
+        Self {
+            rows: RwLock::new(Vec::new()),
+            persist_path: None,
+        }
+    }
+
+    /// Store backed by `<dir>/proof_attempts.jsonl`. Existing rows are
+    /// loaded at startup; malformed lines are skipped with a warning so one
+    /// bad write can never brick the loop.
+    pub fn with_persistence(dir: impl AsRef<Path>) -> std::io::Result<Self> {
+        let dir = dir.as_ref();
+        std::fs::create_dir_all(dir)?;
+        let path = dir.join("proof_attempts.jsonl");
+
+        let mut rows = Vec::new();
+        if path.exists() {
+            let file = std::fs::File::open(&path)?;
+            for (idx, line) in BufReader::new(file).lines().enumerate() {
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<ProofAttempt>(&line) {
+                    Ok(attempt) => rows.push(attempt),
+                    Err(e) => warn!(
+                        line = idx + 1,
+                        error = %e,
+                        "skipping malformed proof_attempts.jsonl row"
+                    ),
+                }
+            }
+            info!(
+                count = rows.len(),
+                path = %path.display(),
+                "loaded persisted proof attempts"
+            );
+        }
+
+        Ok(Self {
+            rows: RwLock::new(rows),
+            persist_path: Some(path),
+        })
+    }
+
+    /// Validate and record one attempt. Returns the attempt_id.
+    ///
+    /// Validation is deliberately minimal — the loop must keep closing even
+    /// for provers/outcomes this build has never heard of. Non-finite
+    /// confidence is rejected; out-of-range confidence is clamped to [0, 1].
+    pub fn record(&self, mut attempt: ProofAttempt) -> Result<String, String> {
+        for (field, value) in [
+            ("attempt_id", &attempt.attempt_id),
+            ("obligation_id", &attempt.obligation_id),
+            ("prover_used", &attempt.prover_used),
+            ("outcome", &attempt.outcome),
+        ] {
+            if value.trim().is_empty() {
+                return Err(format!("{field} must be non-empty"));
+            }
+        }
+        if !attempt.confidence.is_finite() {
+            return Err("confidence must be a finite number".to_string());
+        }
+        attempt.confidence = attempt.confidence.clamp(0.0, 1.0);
+
+        if let Some(path) = &self.persist_path {
+            let line = serde_json::to_string(&attempt).map_err(|e| e.to_string())?;
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .map_err(|e| format!("open {}: {e}", path.display()))?;
+            writeln!(file, "{line}").map_err(|e| format!("append {}: {e}", path.display()))?;
+        }
+
+        let id = attempt.attempt_id.clone();
+        self.rows
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .push(attempt);
+        Ok(id)
+    }
+
+    /// All attempts for one obligation, most recent first, capped at `limit`.
+    pub fn by_obligation(&self, obligation_id: &str, limit: usize) -> Vec<ProofAttempt> {
+        let rows = self
+            .rows
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        rows.iter()
+            .rev()
+            .filter(|a| a.obligation_id == obligation_id)
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
+    /// Per-prover success aggregate for one obligation class, sorted by
+    /// prover name for deterministic output.
+    pub fn success_by_class(&self, obligation_class: &str) -> Vec<ProverSuccessRow> {
+        let rows = self
+            .rows
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut counts: HashMap<String, (u32, u32)> = HashMap::new();
+        for attempt in rows.iter().filter(|a| a.obligation_class == obligation_class) {
+            let entry = counts.entry(attempt.prover_used.clone()).or_insert((0, 0));
+            entry.1 += 1;
+            if attempt.outcome == "success" {
+                entry.0 += 1;
+            }
+        }
+        let mut out: Vec<ProverSuccessRow> = counts
+            .into_iter()
+            .map(|(prover, (successes, total))| ProverSuccessRow {
+                prover,
+                success_rate: successes as f32 / total as f32,
+                total_attempts: total,
+            })
+            .collect();
+        out.sort_by(|a, b| a.prover.cmp(&b.prover));
+        out
+    }
+
+    /// Number of stored attempts.
+    pub fn len(&self) -> usize {
+        self.rows
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len()
+    }
+
+    /// Whether the store is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+// ── HTTP handlers ────────────────────────────────────────────────────────
+
+fn error_json(status: StatusCode, message: impl Into<String>) -> Response {
+    (
+        status,
+        Json(serde_json::json!({ "error": message.into() })),
+    )
+        .into_response()
+}
+
+/// `POST /proof_attempts` — record one attempt, 201 + `{"attempt_id": …}`.
+pub async fn record_handler(
+    State(state): State<AppState>,
+    Json(attempt): Json<ProofAttempt>,
+) -> Response {
+    match state.proof_attempts.record(attempt) {
+        Ok(attempt_id) => (
+            StatusCode::CREATED,
+            Json(serde_json::json!({ "attempt_id": attempt_id })),
+        )
+            .into_response(),
+        Err(message) => error_json(StatusCode::BAD_REQUEST, message),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ListParams {
+    obligation_id: Option<String>,
+    limit: Option<usize>,
+}
+
+/// Hard cap on `limit` so a missing/huge value cannot dump the whole table.
+const MAX_LIST_LIMIT: usize = 500;
+
+/// `GET /proof_attempts?obligation_id={h}&limit={n}` — JSON array, most
+/// recent first. An unknown obligation_id yields `[]` (200, not 404).
+pub async fn list_handler(
+    State(state): State<AppState>,
+    Query(params): Query<ListParams>,
+) -> Response {
+    let Some(obligation_id) = params.obligation_id else {
+        return error_json(
+            StatusCode::BAD_REQUEST,
+            "query parameter 'obligation_id' is required",
+        );
+    };
+    let limit = params.limit.unwrap_or(50).min(MAX_LIST_LIMIT);
+    Json(state.proof_attempts.by_obligation(&obligation_id, limit)).into_response()
+}
+
+#[derive(Deserialize)]
+pub struct ClassParams {
+    class: Option<String>,
+}
+
+/// `GET /mv_prover_success_by_class?class={c}` — JSON array of
+/// `ProverSuccessRow`. A class with no attempts yields `[]` (200, not 404).
+pub async fn success_by_class_handler(
+    State(state): State<AppState>,
+    Query(params): Query<ClassParams>,
+) -> Response {
+    let Some(class) = params.class else {
+        return error_json(
+            StatusCode::BAD_REQUEST,
+            "query parameter 'class' is required",
+        );
+    };
+    Json(state.proof_attempts.success_by_class(&class)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attempt(obligation_id: &str, class: &str, prover: &str, outcome: &str) -> ProofAttempt {
+        ProofAttempt {
+            attempt_id: format!("id-{obligation_id}-{prover}-{outcome}-{}", rand_suffix()),
+            obligation_id: obligation_id.to_string(),
+            repo: "hyperpolymath/echidna".to_string(),
+            file: "proofs/test.v".to_string(),
+            claim: "true".to_string(),
+            obligation_class: class.to_string(),
+            prover_used: prover.to_string(),
+            outcome: outcome.to_string(),
+            duration_ms: 1,
+            confidence: if outcome == "success" { 1.0 } else { 0.0 },
+            parent_attempt_id: None,
+            strategy_tag: "test".to_string(),
+            started_at: "2026-06-11T00:00:00Z".to_string(),
+            completed_at: "2026-06-11T00:00:01Z".to_string(),
+            prover_output: String::new(),
+            error_message: None,
+        }
+    }
+
+    fn rand_suffix() -> u64 {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    #[test]
+    fn record_then_read_back_most_recent_first() {
+        let store = ProofAttemptStore::in_memory();
+        let first = attempt("goal-1", "c", "z3", "failure");
+        let second = attempt("goal-1", "c", "z3", "success");
+        store.record(first.clone()).unwrap();
+        store.record(second.clone()).unwrap();
+        store.record(attempt("goal-2", "c", "z3", "success")).unwrap();
+
+        let rows = store.by_obligation("goal-1", 50);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].attempt_id, second.attempt_id, "most recent first");
+        assert_eq!(rows[1].attempt_id, first.attempt_id);
+        assert!(store.by_obligation("goal-absent", 50).is_empty());
+    }
+
+    #[test]
+    fn limit_caps_results() {
+        let store = ProofAttemptStore::in_memory();
+        for _ in 0..10 {
+            store.record(attempt("goal-cap", "c", "z3", "success")).unwrap();
+        }
+        assert_eq!(store.by_obligation("goal-cap", 3).len(), 3);
+    }
+
+    #[test]
+    fn success_rate_aggregation() {
+        let store = ProofAttemptStore::in_memory();
+        store.record(attempt("g1", "linearity", "z3", "success")).unwrap();
+        store.record(attempt("g2", "linearity", "z3", "success")).unwrap();
+        store.record(attempt("g3", "linearity", "z3", "failure")).unwrap();
+        store.record(attempt("g4", "linearity", "coq", "timeout")).unwrap();
+        store.record(attempt("g5", "termination", "coq", "success")).unwrap();
+
+        let rows = store.success_by_class("linearity");
+        assert_eq!(rows.len(), 2);
+        // Sorted by prover name: coq before z3.
+        assert_eq!(rows[0].prover, "coq");
+        assert_eq!(rows[0].total_attempts, 1);
+        assert_eq!(rows[0].success_rate, 0.0);
+        assert_eq!(rows[1].prover, "z3");
+        assert_eq!(rows[1].total_attempts, 3);
+        assert!((rows[1].success_rate - 2.0 / 3.0).abs() < f32::EPSILON);
+        assert!(rows
+            .iter()
+            .all(|r| (0.0..=1.0).contains(&r.success_rate)));
+        assert!(store.success_by_class("no-such-class").is_empty());
+    }
+
+    #[test]
+    fn validation_rejects_empty_fields_and_bad_confidence() {
+        let store = ProofAttemptStore::in_memory();
+
+        let mut a = attempt("g", "c", "z3", "success");
+        a.attempt_id = "  ".to_string();
+        assert!(store.record(a).is_err());
+
+        let mut b = attempt("g", "c", "z3", "success");
+        b.confidence = f32::NAN;
+        assert!(store.record(b).is_err());
+
+        let mut c = attempt("g", "c", "z3", "success");
+        c.confidence = 7.5;
+        store.record(c).unwrap();
+        assert_eq!(store.by_obligation("g", 1)[0].confidence, 1.0, "clamped");
+    }
+
+    #[test]
+    fn persistence_round_trip() {
+        let dir = std::env::temp_dir().join(format!(
+            "verisim-proof-attempts-test-{}-{}",
+            std::process::id(),
+            rand_suffix()
+        ));
+
+        {
+            let store = ProofAttemptStore::with_persistence(&dir).unwrap();
+            store.record(attempt("g-persist", "c", "lean", "success")).unwrap();
+            store.record(attempt("g-persist", "c", "lean", "failure")).unwrap();
+        }
+
+        // Reopen: rows must come back in insertion order.
+        let reopened = ProofAttemptStore::with_persistence(&dir).unwrap();
+        assert_eq!(reopened.len(), 2);
+        let rows = reopened.by_obligation("g-persist", 50);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].outcome, "failure", "most recent first survives reload");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn persistence_skips_malformed_lines() {
+        let dir = std::env::temp_dir().join(format!(
+            "verisim-proof-attempts-malformed-{}-{}",
+            std::process::id(),
+            rand_suffix()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("proof_attempts.jsonl");
+        let good = serde_json::to_string(&attempt("g-ok", "c", "z3", "success")).unwrap();
+        std::fs::write(&path, format!("{good}\nnot json at all\n")).unwrap();
+
+        let store = ProofAttemptStore::with_persistence(&dir).unwrap();
+        assert_eq!(store.len(), 1, "good row loaded, bad row skipped");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}


### PR DESCRIPTION
## What

Implements the **server side of ECHIDNA's S4 learning loop** — the endpoints `echidna/src/rust/verisim_bridge.rs` has been wired against since 2026-04-27 but which never existed in verisim-api — plus two enabling fixes discovered during the 2026-06-11 ECHIDNA deep review.

### 1. New `proof_attempts` module (`rust-core/verisim-api/src/proof_attempts.rs`)

| Endpoint | Behaviour |
|---|---|
| `POST /api/v1/proof_attempts` | Record one attempt → `201` + `{"attempt_id": …}`; `400` on empty key fields / non-finite confidence; confidence clamped to `[0,1]` |
| `GET /api/v1/proof_attempts?obligation_id={h}&limit={n}` | Attempts for one obligation, most recent first, limit default 50 / cap 500; unknown id → `[]` (200) |
| `GET /api/v1/mv_prover_success_by_class?class={c}` | `[{"prover", "success_rate", "total_attempts"}]`, sorted by prover; unknown class → `[]` (200) |

Shapes mirror the echidna client contract exactly (and the skip/404/parse semantics its `query_*` methods implement). The aggregate keeps its ClickHouse-era `mv_` name because the contract is the path string, not the storage engine — here it's computed on demand over the row store. Storage is in-memory by default, JSONL (`proof_attempts.jsonl`, append-on-record, load-on-start, malformed lines skipped with a warning) under the `persistent` feature. Hypatia's H3 strategy rule reads the same aggregate endpoint when that leg is built.

### 2. `version_prefix` was never applied — fixed via dual mount

`ApiConfig.version_prefix` (`"/api/v1"`) existed in config and the startup log, but `serve()`/`serve_tls()` mounted the router at root only — **every documented `/api/v1/…` path 404'd**, including the octad endpoints echidna's octad writer calls. New `mount_with_prefix()` mounts the router at both root (back-compat: verisim-repl, local tooling) and the prefix (the documented contract).

### 3. `ghcr-publish.yml`

Builds `container/Containerfile`, smoke-tests `/health` + the prefixed S4 endpoint inside the built image, pushes `ghcr.io/hyperpolymath/verisimdb-api:latest` + `:{short-sha}`. This is the published image that echidna's parked S4 CI workflow (`docs/handover/S4-LOOP-CLOSURE-RUNBOOK.md`) has been waiting on.

## Verification

- `cargo test -p verisim-api`: **60/60 green**, including a new end-to-end wire test (`test_s4_proof_attempts_loop`: record → list → aggregate, exercised at both the `/api/v1` and root mounts, plus 400-on-missing-param cases).
- 7 unit tests in the new module (ordering, limit cap, aggregation maths, validation, JSONL round-trip, malformed-line resilience).
- `cargo clippy -p verisim-api` clean.

## Follow-ups (not in this PR)

- Echidna side: build with `--features verisim` + set `VERISIM_URL`, then run `just test-s4-loop` against this server — the loop test should flip from skip to green.
- File echidna's S4 CI workflow once this lands and the first image publishes.
- Hypatia H3 read of `mv_prover_success_by_class` (third leg of the loop).

https://claude.ai/code/session_01DATgBgLA9LfcR8gJHFxzN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DATgBgLA9LfcR8gJHFxzN5)_