### PR TITLE
feat(demo): live consonance-loop demo + CI action pinning + honest KNOWN-ISSUES

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -38,12 +38,12 @@ jobs:
           - elixir: "1.17"
             otp: "27"
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: erlef/setup-beam@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             elixir-orchestration/deps
@@ -63,12 +63,12 @@ jobs:
       run:
         working-directory: elixir-orchestration
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: erlef/setup-beam@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
         with:
           elixir-version: "1.17"
           otp-version: "27"
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             elixir-orchestration/deps
@@ -76,7 +76,7 @@ jobs:
           key: ${{ runner.os }}-mix-coverage-${{ hashFiles('elixir-orchestration/mix.lock') }}
       - run: mix deps.get
       - run: mix coveralls.json
-      - uses: codecov/codecov-action@v7
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: elixir-orchestration/cover/excoveralls.json
           flags: elixir
@@ -90,12 +90,12 @@ jobs:
       run:
         working-directory: elixir-orchestration
     steps:
-      - uses: actions/checkout@v6.0.3
-      - uses: erlef/setup-beam@v1
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
         with:
           elixir-version: "1.17"
           otp-version: "27"
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             elixir-orchestration/deps
@@ -116,9 +116,9 @@ jobs:
       run:
         working-directory: elixir-orchestration
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
         with:
           elixir-version: "1.17"
           otp-version: "27"

--- a/KNOWN-ISSUES.adoc
+++ b/KNOWN-ISSUES.adoc
@@ -8,7 +8,7 @@
 
 == Overview
 
-This document lists known issues, incomplete implementations, and honest gaps in VeriSimDB as of 2026-02-13. Each entry describes the current state, why it matters, and what needs to happen to resolve it.
+This document lists known issues, incomplete implementations, and honest gaps in VeriSimDB as of 2026-06-11. Each entry describes the current state, why it matters, and what needs to happen to resolve it. A full claims-vs-reality review with the active work plan lives at `docs/reviews/2026-06-11-deep-review-and-july-1-plan.adoc`.
 
 A major 7-phase hardening effort was completed on 2026-02-13, resolving most previously-open issues. The remaining open items are documented below.
 
@@ -18,9 +18,11 @@ VeriSimDB is a working system with real implementations in its core modality sto
 
 === 1. Normalizer Regeneration Strategies Are Stubs — ✅ RESOLVED
 
-**Location:** `rust-core/verisim-normalizer/`
+**Location:** `rust-core/verisim-normalizer/`, `rust-core/verisim-api/src/regenerator.rs`
 
-**Resolved:** 2026-02-12. Regeneration strategies now inspect octad data to select the authoritative modality and derive drifted modality content from it, rather than returning hardcoded placeholder strings. Each of the six modality strategies performs actual data transformation.
+**Resolved (write-back + endpoint):** 2026-06-11. The 2026-02-12 fix made the strategies *derive* repaired content but nothing wrote it back to the stores, and `POST /normalizer/trigger/{id}` was a 202 no-op. Now `StoreRegenerator` (verisim-api) implements `ModalityRegenerator` against the live octad store: repairs are written back through `OctadStore::update` (versioned, WAL-logged, recorded on the provenance chain as `normalized` events), the endpoint measures drift, runs the regeneration engine, re-measures from persisted state, and returns before/after scores. Demo: `just demo-consonance`. Honest scope: implemented repair paths are Graph→Document, Document→Vector (deterministic feature-hash embedding, not an ML model), Document/Vector→Tensor; other pairs return an explicit failure instead of fake success; merge regeneration is not implemented.
+
+**Resolved (derivation):** 2026-02-12. Regeneration strategies inspect octad data to select the authoritative modality and derive drifted modality content from it, rather than returning hardcoded placeholder strings.
 
 **Original issue:** Every regeneration strategy returned a hardcoded `[regenerated]` placeholder string instead of actually regenerating data.
 
@@ -252,3 +254,16 @@ Added `rescript.json` for build configuration.
 **Resolved:** 2026-02-28. Protobuf code is now pre-generated and committed at `src/proto/verisim.rs`. The `build.rs` is a no-op. The `prost-build`/`tonic-build` build-dependencies were removed. The Containerfile no longer installs protoc.
 
 **Original issue:** `prost-build` shelled out to the `protoc` binary to compile `verisim.proto`. To regenerate after changing the proto, install protoc and run: `protoc --prost_out=src/proto proto/verisim.proto`.
+
+=== 26. Drift Was Never Measured on Real Data — ✅ RESOLVED
+
+**Location:** `rust-core/verisim-api/src/drift_compute.rs`, `rust-core/verisim-drift/`
+
+**Resolved:** 2026-06-11. `DriftCalculator` contained real drift mathematics but had zero callers: `/drift/status` reported initialized-to-zero metrics forever, and `/drift/entity/{id}` returned the global (zero) worst score labelled as entity-specific. Now every create/update measures the entity's cross-modal drift from its live modality data (graph-document reflection, temporal consistency, tensor shape/data coherence, schema baseline, provenance chain integrity and staleness, spatial validity) and records it into the shared `DriftDetector`; `/drift/entity/{id}` measures THIS entity on demand with a per-component breakdown.
+
+**Honest scope (still open):**
+
+* `semantic_vector_drift` is reported as `computable: false` — measuring it needs a type-embedding registry that does not exist yet. Non-computable components are excluded from the aggregates.
+* `temporal_consistency_drift` works at 1-second timestamp resolution, so two writes within the same second register as a (mild) conflict signal.
+
+**Original issue:** The product's core claim — drift detection — ran on no real data anywhere in the system.

--- a/README.adoc
+++ b/README.adoc
@@ -132,7 +132,41 @@ Consumer repositories should keep their own lightweight VeriSim runtime profiles
 
 Canonical bot policy files for this repository live in `/.machine_readable/bot_directives/`. Root-level `/.bot_directives/` is treated as legacy.
 
-=== Drift Detection Demo
+=== The Consonance Loop, Live (Rust core)
+
+One command, real server, real measurements — no seeded data, no mocks:
+
+[source,bash]
+----
+just demo-consonance        # or: scripts/demo-consonance.sh
+----
+
+The script creates an entity whose document and graph disagree, measures
+the dissonance from the entity's own modality data, asks the normalizer to
+repair it (the document is regenerated from the graph — the authoritative
+source — and the write-back is versioned, WAL-logged, and recorded on the
+provenance chain), then re-measures. Abridged transcript from a real run
+(2026-06-11):
+
+----
+== 2. Measure drift for this entity ==
+  "graph_document": { "score": 0.5,
+    "detail": "0/1 graph relationship targets mentioned in document" }
+
+== 4. Ask the normalizer to repair it ==
+  { "action": "repaired", "modality": "document",
+    "source_modality": "graph",
+    "before_score": 0.5, "after_score": 0.0 }
+
+== 5. Re-measure: the dissonance is gone ==
+  "graph_document": { "score": 0.0,
+    "detail": "1/1 graph relationship targets mentioned in document" }
+
+== 6. The repair is on the audit trail ==
+  { "version_count": 2, "provenance_chain_length": 2 }
+----
+
+=== Drift Detection Demo (Elixir orchestration)
 
 [source,bash]
 ----

--- a/justfile
+++ b/justfile
@@ -76,6 +76,10 @@ serve:
 serve-otp:
     cd elixir-orchestration && MIX_ENV=dev mix run --no-halt
 
+# The consonance loop, live: dissonance -> measured drift -> repair -> re-measure
+demo-consonance:
+    scripts/demo-consonance.sh
+
 # ── Container ──────────────────────────────────────────────────
 
 # Build container image with Podman

--- a/scripts/demo-consonance.sh
+++ b/scripts/demo-consonance.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MPL-2.0
+#
+# demo-consonance.sh — the VeriSimDB consonance loop, end to end, for real.
+#
+# Creates an entity whose document and graph disagree, shows the measured
+# drift, asks the normalizer to repair it, and shows the drift fall to zero
+# with the repair recorded on the provenance chain.
+#
+# Usage:
+#   scripts/demo-consonance.sh            # starts a server on :8814, cleans up
+#   VERISIM_PORT=8080 scripts/demo-consonance.sh   # reuse a running server
+#
+# Requires: curl, jq. Builds verisim-api via cargo if no server is running.
+
+set -euo pipefail
+
+PORT="${VERISIM_PORT:-8814}"
+BASE="http://127.0.0.1:${PORT}"
+SERVER_PID=""
+
+say()  { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+show() { printf '%s\n' "$*"; }
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if ! curl -fsS "${BASE}/health" >/dev/null 2>&1; then
+  say "Starting verisim-api on port ${PORT}"
+  cargo build -p verisim-api --quiet
+  VERISIM_HOST=127.0.0.1 VERISIM_PORT="$PORT" RUST_LOG=warn \
+    ./target/debug/verisim-api &
+  SERVER_PID=$!
+  for _ in $(seq 1 60); do
+    curl -fsS "${BASE}/health" >/dev/null 2>&1 && break
+    sleep 0.5
+  done
+  curl -fsS "${BASE}/health" >/dev/null
+fi
+
+say "1. Create an entity whose document and graph DISAGREE"
+show "   The document never mentions the graph relationship target."
+ID=$(curl -fsS -X POST "${BASE}/octads" \
+  -H 'content-type: application/json' \
+  -d '{
+    "title": "Mission Brief",
+    "body": "A short note that does not mention its relation.",
+    "relationships": [["relates_to", "project-aurora"]],
+    "provenance": {
+      "event_type": "created",
+      "actor": "demo",
+      "source": null,
+      "description": "created by demo-consonance"
+    }
+  }' | jq -r '.id')
+show "   entity id: ${ID}"
+
+say "2. Measure drift for this entity (computed from its own modalities)"
+curl -fsS "${BASE}/drift/entity/${ID}" | jq '{
+  score, status,
+  graph_document: (.components[] | select(.drift_type=="graph_document_drift") | {score, detail}),
+  provenance:     (.components[] | select(.drift_type=="provenance_drift")     | {score, detail})
+}'
+
+say "3. Aggregate drift status (live measurements, not initialized zeros)"
+curl -fsS "${BASE}/drift/status" | jq '[.[] | select(.measurement_count > 0) | {drift_type, current_score, measurement_count}]'
+
+say "4. Ask the normalizer to repair it"
+show "   It regenerates the document from the graph (the authoritative source)"
+show "   and writes the repair back: versioned, WAL-logged, provenance-chained."
+curl -fsS -X POST "${BASE}/normalizer/trigger/${ID}" | jq '{
+  action, modality, source_modality, before_score, after_score
+}'
+
+say "5. Re-measure: the dissonance is gone"
+curl -fsS "${BASE}/drift/entity/${ID}" | jq '{
+  score, status,
+  graph_document: (.components[] | select(.drift_type=="graph_document_drift") | {score, detail})
+}'
+
+say "6. The repair is on the audit trail"
+curl -fsS "${BASE}/octads/${ID}" | jq '{id, version_count, provenance_chain_length}'
+show ""
+show "Consonance loop complete: dissonance created -> measured -> repaired -> re-measured."


### PR DESCRIPTION
Follow-up tranche to the merged #120, completing Week-1 item 5 of the July-1 plan plus two truth/hygiene items.

**Demo (run for real this session):** `just demo-consonance` / `scripts/demo-consonance.sh` — starts `verisim-api`, creates an entity whose document and graph disagree, measures drift from the entity's own modalities (`graph_document_drift: 0.5`, "0/1 targets mentioned"), triggers the normalizer (document regenerated from the graph; write-back versioned, WAL-logged, provenance-chained), re-measures (`0.0`, "1/1 mentioned"), and shows the audit trail (`provenance_chain_length: 1 → 2`). The README gains a "Consonance Loop, Live" section with the real transcript.

**CI pinning:** all four actions in `elixir-ci.yml` pinned to upstream-verified commit SHAs (tags resolved via `git ls-remote`, annotated tags dereferenced — codecov's floating `v7` tag object differs from its commit; pinned to the commit `fb8b3582…`). Clears the recurring Hypatia `unpinned_action` findings.

**KNOWN-ISSUES truth pass:** issue 1 re-scoped (derivation landed 2026-02-12; write-back + endpoint landed 2026-06-11); new issue 26 records the drift-never-measured gap as resolved, with the remaining honest scope stated (semantic-vector drift unmeasurable pending a type-embedding registry; 1-second temporal resolution).

Workspace remains green: 620 tests passed / 0 failed, clippy clean under `-D warnings`.

https://claude.ai/code/session_01E8BpV19yxhf67UrCrvkfTr

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BpV19yxhf67UrCrvkfTr)_