### PR TITLE
fix(security): harden VQL modality telemetry atoms + audited FP classifications

### DIFF
--- a/audits/assail-classifications.a2ml
+++ b/audits/assail-classifications.a2ml
@@ -1,0 +1,61 @@
+;; SPDX-License-Identifier: MPL-2.0
+;; assail-classifications.a2ml — audited panic-attack findings for verisimdb.
+;;
+;; Read by panic-attack >= 2.5.5 (load_user_classifications): findings
+;; matching (file, category) flip to suppressed = true after the kanren
+;; structural pass. Entries are AUDITED-SOUND residuals with rationale;
+;; the registry lives apart from the source so a code edit cannot
+;; self-suppress (panic-attack CLAUDE.md, User-Classification Registry).
+;;
+;; Audit trail: 2026-06-11 estate-loop session — fresh panic-attack
+;; 2.5.5 scan; every entry inspected at source.
+
+(assail-classifications
+  ;; ── Documentation examples misread as credentials ────────────────
+  (classification
+    (file "elixir-orchestration/lib/verisim/federation/adapters/object_storage.ex")
+    (category "HardcodedSecret")
+    (audit "object_storage.ex:25-50 @moduledoc — MinIO/S3 configuration examples")
+    (rationale "doc examples; \"minioadmin\" is MinIO's published default (matches test-infra), \"AKIA...\" is a literal ellipsis placeholder"))
+  (classification
+    (file "connectors/clients/elixir/lib/verisim_client/federation.ex")
+    (category "HardcodedSecret")
+    (audit "federation.ex:21 @moduledoc usage example — api_key: \"example-peer-key-123\"")
+    (rationale "doc example with example- prefixed placeholder; no credential present"))
+
+  ;; ── stringify→parseExn round-trips inside try blocks ─────────────
+  ;; `params->Obj.magic->JSON.stringify->JSON.parseExn` cannot fail
+  ;; (stringify output is always valid JSON) and every call site is
+  ;; inside `try { } catch` returning result<_, VeriSimError.t>. The
+  ;; graceful degradation the finding asks for is already present.
+  (classification
+    (file "connectors/clients/rescript/src/VeriSimVql.res")
+    (category "UnsafeDeserialization")
+    (audit "try-wrapped stringify→parseExn round-trips")
+    (rationale "parse of self-stringified JSON inside try; cannot throw on external input"))
+  (classification
+    (file "connectors/clients/rescript/src/VeriSimFederation.res")
+    (category "UnsafeDeserialization")
+    (audit "try-wrapped stringify→parseExn round-trips")
+    (rationale "parse of self-stringified JSON inside try; cannot throw on external input"))
+  (classification
+    (file "connectors/clients/rescript/src/VeriSimProvenance.res")
+    (category "UnsafeDeserialization")
+    (audit "try-wrapped stringify→parseExn round-trips")
+    (rationale "parse of self-stringified JSON inside try; cannot throw on external input"))
+  (classification
+    (file "connectors/clients/rescript/src/VeriSimDrift.res")
+    (category "UnsafeDeserialization")
+    (audit "VeriSimDrift.res:77 — JSON.parseExn(\"{}\") constant, inside try")
+    (rationale "parse of a constant literal inside try; cannot throw"))
+  (classification
+    (file "connectors/clients/rescript/src/VeriSimHexad.res")
+    (category "UnsafeDeserialization")
+    (audit "try-wrapped stringify→parseExn round-trips")
+    (rationale "parse of self-stringified JSON inside try; cannot throw on external input"))
+  (classification
+    (file "connectors/clients/rescript/src/VeriSimSearch.res")
+    (category "UnsafeDeserialization")
+    (audit "VeriSimSearch.res:80-200 — six try-wrapped stringify→parseExn round-trips")
+    (rationale "parse of self-stringified JSON inside try; cannot throw on external input"))
+)

--- a/connectors/clients/elixir/lib/verisim_client/federation.ex
+++ b/connectors/clients/elixir/lib/verisim_client/federation.ex
@@ -18,7 +18,7 @@ defmodule VeriSimClient.Federation do
         "us-west-replica",
         "https://peer.example.com:8080",
         "verisimdb",
-        %{api_key: "peer-key-123"}
+        %{api_key: "example-peer-key-123"}
       )
 
       {:ok, peers} = VeriSimClient.Federation.list_peers(client)

--- a/elixir-orchestration/lib/verisim/query/vql_executor.ex
+++ b/elixir-orchestration/lib/verisim/query/vql_executor.ex
@@ -145,7 +145,7 @@ defmodule VeriSim.Query.VQLExecutor do
     ~w(GRAPH VECTOR TENSOR SEMANTIC DOCUMENT TEMPORAL PROVENANCE SPATIAL)
     |> Enum.filter(&String.contains?(upper, &1))
     |> Enum.map(&String.downcase/1)
-    |> Enum.map(&String.to_atom/1)
+    |> Enum.map(&String.to_existing_atom/1)
   end
 
   # ===========================================================================


### PR DESCRIPTION
Part of the estate loop repair (hyperpolymath/hypatia#458).

## What

1. **`vql_executor.ex`**: `extract_modalities_from_string` now maps via `String.to_existing_atom`. The candidate list is the fixed 8-modality table and all 8 atoms are compile-time literals in this very module (26 references), so behaviour is identical — but dynamic atom creation from query strings (PA013 AtomExhaustion, flagged High on a user-facing query path) is structurally ruled out.
2. **`federation.ex`** doc example: `"peer-key-123"` → `"example-peer-key-123"` per the estate placeholder-prefix convention.
3. **`audits/assail-classifications.a2ml`**: audited-FP registry for the residuals from a fresh panic-attack 2.5.5 scan — `@moduledoc` configuration examples (`minioadmin` is MinIO's published default matching test-infra; `"AKIA..."` is a literal ellipsis) and six ReScript SDK files whose `JSON.parseExn` calls are try-wrapped `stringify→parseExn` round-trips that cannot throw on external input (verified at each call site).

## Verification

Fresh scan after this change: verisimdb unsuppressed **non-heuristic Critical/High = 0**. The stale verisimdb-data store showed 3 Criticals: two `believe_me` entries for `Foreign.idr` content already fixed and a third for a path that no longer exists — flushed by hypatia#458's estate-rescan.

https://claude.ai/code/session_01EzjC8MEx3Kzf3pdMhaQSks

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzjC8MEx3Kzf3pdMhaQSks)_