### PR TITLE
fix(ci): unbreak main — A2ML gate dialect exclusion + integration tests opt-in

### DIFF
--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -30,7 +30,11 @@ jobs:
       - name: Check for A2ML files
         id: detect
         run: |
-          COUNT=$(find . -name '*.a2ml' -not -path './.git/*' | wc -l)
+          # audits/assail-classifications.a2ml is panic-attack's user-classification
+          # registry — an S-expression dialect by that tool's spec (see panic-attack
+          # CLAUDE.md), not the TOML-like manifest A2ML this gate validates. Exclude
+          # it rather than feeding it to a validator for a different dialect.
+          COUNT=$(find . -name '*.a2ml' -not -path './.git/*' -not -name 'assail-classifications.a2ml' | wc -l)
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" -eq 0 ]; then
             echo "::warning::No .a2ml manifest files found. Every RSR repo should have 0-AI-MANIFEST.a2ml"
@@ -42,6 +46,19 @@ jobs:
         with:
           path: '.'
           strict: 'false'
+          # Re-state the action's default carve-outs (a custom value REPLACES
+          # the default list), plus panic-attack's user-classification
+          # registry: that file is an S-expression dialect by panic-attack's
+          # spec, not the TOML-like manifest A2ML this action validates.
+          paths-ignore: |
+            vendor/
+            vendored/
+            verified-container-spec/
+            .audittraining/
+            integration/fixtures/
+            test/fixtures/
+            tests/fixtures/
+            assail-classifications.a2ml
 
       - name: Write summary
         run: |

--- a/audits/assail-classifications.a2ml
+++ b/audits/assail-classifications.a2ml
@@ -1,4 +1,5 @@
 ;; SPDX-License-Identifier: MPL-2.0
+;; Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 ;; assail-classifications.a2ml — audited panic-attack findings for verisimdb.
 ;;
 ;; Read by panic-attack >= 2.5.5 (load_user_classifications): findings

--- a/elixir-orchestration/test/test_helper.exs
+++ b/elixir-orchestration/test/test_helper.exs
@@ -1,3 +1,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
-ExUnit.start()
+# Integration tests (7 adapter suites under
+# test/verisim/federation/adapters/integration/) require the test-infra
+# database stack (connectors/test-infra). They are opt-in per the
+# documented flow — `mix test --include integration` — but were never
+# actually excluded here, so bare `mix test` (what elixir-ci.yml runs)
+# failed all 90 of them with "not available — start test-infra stack"
+# on every CI run.
+ExUnit.start(exclude: [:integration])


### PR DESCRIPTION
Follow-up to #123, which merged before these CI fixes were pushed — **main is currently red on both counts**:

1. **`dogfood-gate` / "Validate A2ML manifests"**: `audits/assail-classifications.a2ml` (landed in #123) is panic-attack's user-classification registry — an S-expression dialect per that tool's spec, not the TOML-like manifest A2ML the gate validates. Excluded via the validate action's `paths-ignore` (the action's defaults are restated, since a custom value replaces them) and the detect-count `find`. Also adds the REUSE copyright line to the registry header.

2. **`elixir-ci` "compile + test" + ExCoveralls**: the 7 federation-adapter integration suites require the `connectors/test-infra` database stack and are documented as opt-in (`mix test --include integration` — see CLAUDE.md Test Infrastructure), but `test_helper.exs` never excluded them, so bare `mix test` failed all 90 with "Neo4j not available — start test-infra stack" on every CI run (pre-existing red, predates #123). `ExUnit.start(exclude: [:integration])` restores the documented contract.

https://claude.ai/code/session_01EzjC8MEx3Kzf3pdMhaQSks

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzjC8MEx3Kzf3pdMhaQSks)_