### PR TITLE
ci(workflows): timeout-minutes + SHA-pinned actions

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -14,6 +14,7 @@ jobs:
   validate-rust:
     name: Rust build validation
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -23,6 +24,7 @@ jobs:
   validate-elixir:
     name: Elixir build validation
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: elixir-orchestration

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -10,6 +10,7 @@ permissions: read-all
 jobs:
   batch-fuzzing:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   pr-fuzzing:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,7 @@ permissions: read-all
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/coq-build.yml
+++ b/.github/workflows/coq-build.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     name: Compile Coq proofs + assumptions guard
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -22,6 +22,7 @@ jobs:
   a2ml-validate:
     name: Validate A2ML manifests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -29,6 +29,7 @@ jobs:
   build-test:
     name: compile + test
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: elixir-orchestration
@@ -62,6 +63,7 @@ jobs:
     # coveralls.json, so they don't dilute the unit-coverage denominator.
     name: ExCoveralls (unit, gate in coveralls.json)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: elixir-orchestration
@@ -89,6 +91,7 @@ jobs:
   bench-compile:
     name: benchee scripts compile
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: elixir-orchestration
@@ -115,6 +118,7 @@ jobs:
   audit:
     name: hex audit
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: elixir-orchestration

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -22,6 +22,7 @@ jobs:
   fuzz-core:
     name: Core Fuzz Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -37,6 +38,7 @@ jobs:
   fuzz-debugger:
     name: Debugger Fuzz Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:

--- a/.github/workflows/instant-sync.yml
+++ b/.github/workflows/instant-sync.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Trigger Propagation
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v3

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -19,6 +19,7 @@ jobs:
   reuse-lint:
     name: reuse lint
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -27,6 +27,7 @@ jobs:
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -37,6 +38,7 @@ jobs:
   clippy:
     name: clippy (all-targets)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -48,6 +50,7 @@ jobs:
   test:
     name: cargo test
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -57,6 +60,7 @@ jobs:
   doc:
     name: cargo doc
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       RUSTDOCFLAGS: "-D warnings"
     steps:
@@ -68,6 +72,7 @@ jobs:
   audit:
     name: cargo audit
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
@@ -77,6 +82,7 @@ jobs:
   deny:
     name: cargo deny
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
@@ -86,6 +92,7 @@ jobs:
   bench-compile:
     name: benchmarks compile
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -95,6 +102,7 @@ jobs:
   coverage:
     name: cargo-llvm-cov (≥60%)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -120,6 +128,7 @@ jobs:
     # into a separate pr-mutants.yml once the suite stabilises.
     name: cargo-mutants (on-demand)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
@@ -149,6 +158,7 @@ jobs:
   fuzz-compile:
     name: fuzz targets compile
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         manifest:

--- a/.github/workflows/scorecard-enforcer.yml
+++ b/.github/workflows/scorecard-enforcer.yml
@@ -22,6 +22,7 @@ permissions: read-all
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       security-events: write
       id-token: write  # For OIDC
@@ -60,6 +61,7 @@ jobs:
   # Check specific high-priority items
   check-critical:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 


### PR DESCRIPTION
## Summary

Hardens all GitHub Actions workflows with `timeout-minutes: 60` on every steps-based job, and confirms all action `uses:` lines are already SHA-pinned.

## Jobs that received `timeout-minutes: 60`

27 jobs across 12 files:

| File | Jobs |
|------|------|
| `build-validation.yml` | `validate-rust`, `validate-elixir` |
| `reuse.yml` | `reuse-lint` |
| `cflite_pr.yml` | `pr-fuzzing` |
| `cflite_batch.yml` | `batch-fuzzing` |
| `fuzz.yml` | `fuzz-core`, `fuzz-debugger` |
| `instant-sync.yml` | `dispatch` |
| `scorecard-enforcer.yml` | `scorecard`, `check-critical` |
| `dogfood-gate.yml` | `a2ml-validate` |
| `elixir-ci.yml` | `build-test`, `coverage`, `bench-compile`, `audit` |
| `coq-build.yml` | `build` |
| `rust-ci.yml` | `fmt`, `clippy`, `test`, `doc`, `audit`, `deny`, `bench-compile`, `coverage`, `mutants`, `fuzz-compile` |
| `codeql.yml` | `analyze` |

Already had `timeout-minutes: 60`: `ghcr-publish.yml` → `build-and-push` (unchanged).

## Reusable-workflow caller jobs — intentionally left WITHOUT `timeout-minutes`

`timeout-minutes` is invalid on jobs that use `uses:` at the job level (reusable-workflow callers). These were correctly left untouched:

| File | Job | Calls |
|------|-----|-------|
| `hypatia-scan.yml` | `hypatia` | `hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@…` |
| `governance.yml` | `governance` | `hyperpolymath/standards/.github/workflows/governance-reusable.yml@…` |
| `security-scan.yml` | `scan` | `hyperpolymath/panic-attacker/.github/workflows/scan-and-report.yml@…` |
| `secret-scanner.yml` | `scan` | `hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@…` |
| `spark-theatre-gate.yml` | `spark-theatre-gate` | `hyperpolymath/standards/.github/workflows/spark-theatre-gate.yml@…` |
| `scorecard.yml` | `analysis` | `hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@…` |
| `mirror.yml` | `mirror` | `hyperpolymath/standards/.github/workflows/mirror-reusable.yml@…` |

## SHA-pinned actions

No new pinning was required — all `uses:` lines in step definitions were already pinned to 40-hex SHAs at the time of this PR. Verification:

```
grep -rn 'uses: [^#]*@v[0-9]' .github/workflows/
(no output — zero unpinned actions)
```

## Verification

**YAML parse (all 20 files):**
```
OK: build-validation.yml, cflite_batch.yml, cflite_pr.yml, codeql.yml,
    coq-build.yml, dogfood-gate.yml, elixir-ci.yml, fuzz.yml,
    ghcr-publish.yml, governance.yml, hypatia-scan.yml, instant-sync.yml,
    mirror.yml, reuse.yml, rust-ci.yml, scorecard-enforcer.yml,
    scorecard.yml, secret-scanner.yml, security-scan.yml,
    spark-theatre-gate.yml
```

**No unpinned actions:** `grep -rn 'uses: [^#]*@v[0-9]' .github/workflows/` → no matches

**reuse lint:** COMPLIANT — 768/768 files with copyright + license information (REUSE 3.3)

---

https://claude.ai/code/session_01W9Voe3JceP66Bna9FT4jME

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9Voe3JceP66Bna9FT4jME)_