### PR TITLE
docs: drop Palimpsest branding → Mozilla Public License 2.0 (MPL-2.0)

### DIFF
--- a/.machine_readable/contractiles/_base.ncl
+++ b/.machine_readable/contractiles/_base.ncl
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MPL-2.0
-# (MPL-2.0 is automatic legal fallback until PMPL is formally recognised)
+# (Licensed under MPL-2.0)
 #
 # _base.ncl — Shared contractile base
 #

--- a/.machine_readable/svc/k9/examples/setup-repo.k9.ncl
+++ b/.machine_readable/svc/k9/examples/setup-repo.k9.ncl
@@ -132,7 +132,7 @@ K9!
     "add-license" = {
       description = "Add MPL-2.0 license",
       commands = [
-        "curl -sL https://raw.githubusercontent.com/hyperpolymath/pmpl/main/LICENSE -o LICENSE",
+        "curl -sL https://www.mozilla.org/media/MPL/2.0/index.txt -o LICENSE",
         "echo '✓ License added'",
       ],
     },

--- a/.well-known/void.rdf
+++ b/.well-known/void.rdf
@@ -8,7 +8,7 @@
     <void:Dataset rdf:about="https://verisimdb.dev/dataset">
         <dcterms:title>verisimdb Dataset</dcterms:title>
         <dcterms:description>Linked data from verisimdb project</dcterms:description>
-        <dcterms:license rdf:resource="https://palimpsest.spdx.dev"/>
+        <dcterms:license rdf:resource="https://spdx.org/licenses/MPL-2.0.html"/>
         <void:sparqlEndpoint rdf:resource="https://verisimdb.dev/sparql"/>
         <void:dataDump rdf:resource="https://verisimdb.dev/dataset.ttl"/>
     </void:Dataset>

--- a/.well-known/void.ttl
+++ b/.well-known/void.ttl
@@ -12,7 +12,7 @@
     dcterms:description "Linked data from verisimdb project" ;
     dcterms:creator <https://verisimdb.dev#creator> ;
     dcterms:publisher <https://verisimdb.dev#publisher> ;
-    dcterms:license <https://palimpsest.spdx.dev> ;
+    dcterms:license <https://spdx.org/licenses/MPL-2.0.html> ;
     dcterms:created "2026-01-31T16:49:57Z"^^xsd:dateTime ;
     dcterms:modified "2026-01-31T16:49:57Z"^^xsd:dateTime ;
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ cargo fmt --check
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the **MPL-2.0** (Palimpsest License). All source files must include:
+By contributing, you agree that your contributions will be licensed under the **MPL-2.0**. All source files must include:
 
 ```
 // SPDX-License-Identifier: MPL-2.0

--- a/docs/.well-known/void.rdf
+++ b/docs/.well-known/void.rdf
@@ -8,7 +8,7 @@
     <void:Dataset rdf:about="https://verisimdb.dev/dataset">
         <dcterms:title>verisimdb Dataset</dcterms:title>
         <dcterms:description>Linked data from verisimdb project</dcterms:description>
-        <dcterms:license rdf:resource="https://palimpsest.spdx.dev"/>
+        <dcterms:license rdf:resource="https://spdx.org/licenses/MPL-2.0.html"/>
         <void:sparqlEndpoint rdf:resource="https://verisimdb.dev/sparql"/>
         <void:dataDump rdf:resource="https://verisimdb.dev/dataset.ttl"/>
     </void:Dataset>

--- a/docs/.well-known/void.ttl
+++ b/docs/.well-known/void.ttl
@@ -12,7 +12,7 @@
     dcterms:description "Linked data from verisimdb project" ;
     dcterms:creator <https://verisimdb.dev#creator> ;
     dcterms:publisher <https://verisimdb.dev#publisher> ;
-    dcterms:license <https://palimpsest.spdx.dev> ;
+    dcterms:license <https://spdx.org/licenses/MPL-2.0.html> ;
     dcterms:created "2026-01-31T16:49:57Z"^^xsd:dateTime ;
     dcterms:modified "2026-01-31T16:49:57Z"^^xsd:dateTime ;
 

--- a/docs/business/business-case.adoc
+++ b/docs/business/business-case.adoc
@@ -33,7 +33,7 @@ downstream systems consume stale or contradictory information.
 This capability positions VeriSimDB at the intersection of three high-growth
 markets: data quality tools ($2.3B by 2027), graph databases ($5.6B), and the
 emerging multimodal database segment ($800M+). The open-core business model
-provides a free, full-featured community edition under the Palimpsest License
+provides a free, full-featured community edition under the Mozilla Public License 2.0 (MPL-2.0)
 (MPL-2.0), with revenue generated through commercial support licenses,
 enterprise SLAs, and deployment consulting.
 

--- a/docs/business/marketing/one-pager.adoc
+++ b/docs/business/marketing/one-pager.adoc
@@ -40,7 +40,7 @@ cross-modal consistency monitoring.
   with optional dependent-type proofs (VQL-DT) for compile-time query verification
 * *Federation* -- Bring drift detection to existing infrastructure by federating
   across PostgreSQL, ArangoDB, Elasticsearch, Neo4j, and more
-* *Open source* -- Full-featured community edition under the Palimpsest License
+* *Open source* -- Full-featured community edition under the Mozilla Public License 2.0 (MPL-2.0)
   (MPL-2.0); no feature gating
 
 === Technical Differentiators
@@ -76,4 +76,4 @@ cross-modal consistency monitoring.
 ''''
 
 _VeriSimDB is developed by Jonathan D.A. Jewell at hyperpolymath._
-_Licensed under MPL-2.0 (Palimpsest License)._
+_Licensed under MPL-2.0._

--- a/docs/business/pr/faq.adoc
+++ b/docs/business/pr/faq.adoc
@@ -216,7 +216,7 @@ operate as a standalone database without any external connections.
 
 === Is VeriSimDB open source?
 
-Yes. VeriSimDB is released under the *Palimpsest License (MPL-2.0)*,
+Yes. VeriSimDB is released under the *Mozilla Public License 2.0 (MPL-2.0)*,
 a permissive open-source license. The community edition is full-featured with
 no artificial restrictions -- all 8 modalities, drift detection,
 self-normalisation, VQL, and federation are included.

--- a/docs/business/pr/press-release.adoc
+++ b/docs/business/pr/press-release.adoc
@@ -54,7 +54,7 @@ data migration.
 
 === Availability and Licensing
 
-VeriSimDB is available immediately as open source under the *Palimpsest License
+VeriSimDB is available immediately as open source under the *Mozilla Public License 2.0 (MPL-2.0)
 (MPL-2.0)*, a permissive open-source license. The community edition
 is full-featured with no artificial restrictions. Commercial support licenses
 with enterprise SLAs, priority security patches, and deployment consulting are

--- a/docs/papers/verisimdb-federated-consistency.adoc
+++ b/docs/papers/verisimdb-federated-consistency.adoc
@@ -810,7 +810,7 @@ The 11 proof types cover a range of assurance levels from basic existence checki
 
 Federation extends these guarantees across organisational boundaries, enabling multi-institutional data sharing with configurable drift policies that balance consistency against latency and autonomy.
 
-VeriSimDB is open source under the Palimpsest License (MPL-2.0), with the Rust core, Elixir orchestration layer, and VQL parser available at https://github.com/hyperpolymath/verisimdb.
+VeriSimDB is open source under the Mozilla Public License 2.0 (MPL-2.0), with the Rust core, Elixir orchestration layer, and VQL parser available at https://github.com/hyperpolymath/verisimdb.
 
 
 // ============================================================================

--- a/docs/releases/v0.1.0-alpha.md
+++ b/docs/releases/v0.1.0-alpha.md
@@ -339,7 +339,7 @@ Run full benchmarks: `cd benches && cargo bench`
 
 ## 📄 License
 
-VeriSimDB is licensed under **MPL-2.0** (Palimpsest License).
+VeriSimDB is licensed under **MPL-2.0**.
 
 Third-party components retain their original licenses (MIT, Apache, BSD, etc.).
 

--- a/docs/rsr-compliance.adoc
+++ b/docs/rsr-compliance.adoc
@@ -1,6 +1,6 @@
 = RSR Template Repository
 
-image:[Palimpsest-MPL-1.0,link="https://github.com/hyperpolymath/palimpsest-license"] image:[Palimpsest,link="https://github.com/hyperpolymath/palimpsest-license"]
+image:https://img.shields.io/badge/License-MPL--2.0-brightgreen[License: MPL-2.0,link="https://www.mozilla.org/en-US/MPL/2.0/"]
 :toc:
 :sectnums:
 
@@ -69,7 +69,7 @@ just validate-rsr
 |Task runner with 50+ recipes
 
 |`LICENSE.txt`
-|MPL-2.0 (Palimpsest License)
+|MPL-2.0
 
 |`README.adoc`
 |This file


### PR DESCRIPTION
Completes the owner decision (2026-06-13) to **drop the Palimpsest License brand entirely** — the licence is **MPL-2.0**. #130 did a *partial* PMPL→MPL reword that left "Palimpsest License" across ~14 files and even created a self-contradiction in `faq.adoc`; this removes it completely.

## Fixed (14 files — `git grep -i 'palimpsest|PMPL'` → **0** outside historical octads; `reuse lint` PASS 768/768)
- `docs/business/pr/faq.adoc` — resolves the self-contradiction (l.219 "Palimpsest License (MPL-2.0)" vs l.226 "Mozilla Public License 2.0").
- `.well-known/void.{rdf,ttl}` ×2 dirs — licence URI `palimpsest.spdx.dev` → `https://spdx.org/licenses/MPL-2.0.html`.
- `CONTRIBUTING.md`; `rsr-compliance.adoc` badge → a real MPL-2.0 shields badge; business/marketing/PR/paper/release prose → "Mozilla Public License 2.0 (MPL-2.0)".
- `.machine_readable/contractiles/_base.ncl` — drops the "fallback until PMPL is formally recognised" note.
- `.machine_readable/svc/k9/examples/setup-repo.k9.ncl` — the `curl …/hyperpolymath/pmpl/…/LICENSE` → canonical MPL-2.0 text URL.
- **Left intact:** historical commit data under `.verisimdb/octads/` (a record of the past, not current licensing).

https://claude.ai/code/session_01W9Voe3JceP66Bna9FT4jME

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9Voe3JceP66Bna9FT4jME)_