### PR TITLE
fix(nif): fail loudly instead of faking success (silent data-loss tripwire)

### DIFF
--- a/KNOWN-ISSUES.adoc
+++ b/KNOWN-ISSUES.adoc
@@ -275,3 +275,15 @@ Added `rescript.json` for build configuration.
 **Resolved:** 2026-06-13. The text, vector, and similar-query search endpoints all reported `score: 1.0 - (i as f32 * 0.1)` — a synthetic sequence derived from result position, discarding the real relevance scores the modality stores already compute (Tantivy BM25 for documents, cosine similarity for vectors). The octad store now exposes `search_text_scored` / `search_similar_scored` (returning `Vec<(Octad, f32)>`); the three handlers surface those real scores. Test `test_vector_search_returns_real_cosine_scores` pins the distinction (the second hit reports its true ~0.994 cosine, not synthetic 0.9).
 
 **Original issue:** API search responses carried fabricated scores, so any client ranking or thresholding on `score` was meaningless.
+
+=== 28. NIF Transport Faked Success (Silent Data Loss) — ✅ RESOLVED
+
+**Location:** `rust-core/verisim-nif/src/lib.rs`, `elixir-orchestration/lib/verisim/{nif_bridge,transport}.ex`
+
+**Resolved:** 2026-06-13. The `verisim-nif` Rustler bridge is a scaffold — no operation is wired to the store — but every NIF returned *canned success* JSON: `delete_octad` replied `{"status":"deleted"}`, `create_octad` `{"status":"created"}`, `get_drift_score` all-zeros. When the `.so` was compiled in, `:erlang.load_nif` overrode the honest Elixir fallback stubs with these, `NifBridge.loaded?` reported `true`, and `VERISIM_TRANSPORT=nif` *or* `auto` selected the NIF — so a write returned success having stored/deleted nothing: **silent data loss reported as success.** (Without the `.so`, the pure-Elixir stubs already returned `{:error, :nif_not_loaded}`, so the danger was the compiled artifact only.)
+
+Now every NIF returns `{:error, :not_implemented}` — fail loudly, never fake. The compiled NIF and the absent-library stub are now indistinguishable to callers (both non-operational, both error). `NifBridge.loaded?` is redefined to mean *operational* (a probe returns a real result), so `auto` correctly falls back to HTTP; explicit `nif` surfaces the error rather than fabricating data; and `Transport.health/0` no longer returns a hardcoded `healthy` under nif. Regression test `VeriSim.TransportTest` asserts no operation ever returns fake success.
+
+This was an instance of the project's recurring *silent fake-success* defect class (see also issues 26, 27): code returning a success value without performing the named effect. None of the CI scanners (Hypatia, panic-attack, gitleaks) flag it — it has no dangerous *shape* — so it is caught only by reading code against its claims.
+
+**Original issue:** The NIF bridge fabricated success for unimplemented operations, risking silent data loss under the NIF/auto transports.

--- a/elixir-orchestration/lib/verisim/nif_bridge.ex
+++ b/elixir-orchestration/lib/verisim/nif_bridge.ex
@@ -13,7 +13,11 @@ defmodule VeriSim.NifBridge do
   The NIF shared library is loaded from `priv/native/libverisim_nif.so` (Linux)
   or `priv/native/libverisim_nif.dylib` (macOS). If the library is not present
   (e.g., in a pure-Elixir development setup), all functions return
-  `{:error, :nif_not_loaded}`.
+  `{:error, :nif_not_loaded}`. If the library IS present but an operation is
+  not yet wired to the store, that operation returns `{:error, :not_implemented}`
+  — it never fabricates success. Today every operation is a not-implemented
+  stub (see `rust-core/verisim-nif`), so the NIF is non-operational and `auto`
+  transport always falls back to HTTP.
 
   ## Transport Selection
 
@@ -107,12 +111,18 @@ defmodule VeriSim.NifBridge do
   def trigger_normalise(_octad_id), do: {:error, :nif_not_loaded}
 
   @doc """
-  Check whether the NIF bridge is loaded and operational.
+  Check whether the NIF bridge is loaded **and operational**.
+
+  Returns `true` only when a probe operation returns a real result. Both the
+  absent-library fallback (`{:error, :nif_not_loaded}`) and a loaded-but-
+  unimplemented NIF (`{:error, :not_implemented}`) read as *not operational*,
+  so `auto` transport never selects a NIF that cannot actually serve a
+  request. When every operation is a not-implemented stub, this is `false`.
   """
   def loaded? do
     case get_octad("__health_check__") do
-      {:error, :nif_not_loaded} -> false
-      _ -> true
+      result when is_binary(result) -> true
+      _ -> false
     end
   end
 end

--- a/elixir-orchestration/lib/verisim/transport.ex
+++ b/elixir-orchestration/lib/verisim/transport.ex
@@ -71,10 +71,21 @@ defmodule VeriSim.Transport do
 
   @doc """
   Check health of the Rust core.
+
+  Under `:http` (and `:auto`, which falls back to HTTP while the NIF is
+  non-operational) this probes the real verisim-api. Under an explicit
+  `:nif` it reports honestly that the NIF transport is not operational
+  rather than fabricating a `healthy` status — the NIF has no implemented
+  operations to be healthy about.
   """
   def health do
     if use_nif?() do
-      {:ok, %{"status" => "healthy", "transport" => "nif"}}
+      Logger.warning(
+        "VERISIM_TRANSPORT=nif selected but the NIF bridge has no implemented " <>
+          "operations; reporting not operational. Use VERISIM_TRANSPORT=http."
+      )
+
+      {:error, :nif_not_operational}
     else
       RustClient.health()
     end

--- a/elixir-orchestration/test/verisim/query/vcl_executor_test.exs
+++ b/elixir-orchestration/test/verisim/query/vcl_executor_test.exs
@@ -24,6 +24,17 @@ defmodule VeriSim.Query.VCLExecutorTest do
   use ExUnit.Case, async: false
 
   alias VeriSim.Query.VCLExecutor
+  alias VeriSim.Test.VCLTestHelpers, as: H
+
+  setup_all do
+    # `execute_string/2` routes through the VCLBridge parser singleton. Every
+    # other VCL test file starts that GenServer in its own setup; this file did
+    # not, so its execute_string tests passed only when a bridge-starting file
+    # happened to run earlier (a seed-order dependency). Start it explicitly so
+    # the suite is order-independent.
+    H.ensure_bridge_started()
+    :ok
+  end
 
   describe "execute/2 with :explain option" do
     test "returns a structured plan with the documented keys" do

--- a/elixir-orchestration/test/verisim/transport_test.exs
+++ b/elixir-orchestration/test/verisim/transport_test.exs
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MPL-2.0
+
+defmodule VeriSim.TransportTest do
+  # async: false — these tests mutate the VERISIM_TRANSPORT OS env var.
+  use ExUnit.Case, async: false
+
+  alias VeriSim.{NifBridge, Transport}
+
+  setup do
+    prior = System.get_env("VERISIM_TRANSPORT")
+
+    on_exit(fn ->
+      if prior,
+        do: System.put_env("VERISIM_TRANSPORT", prior),
+        else: System.delete_env("VERISIM_TRANSPORT")
+    end)
+
+    :ok
+  end
+
+  describe "transport mode selection" do
+    test "defaults to :http when unset" do
+      System.delete_env("VERISIM_TRANSPORT")
+      assert Transport.mode() == :http
+      refute Transport.use_nif?()
+    end
+
+    test "explicit nif selects :nif" do
+      System.put_env("VERISIM_TRANSPORT", "nif")
+      assert Transport.mode() == :nif
+    end
+
+    test "auto does NOT select the NIF while it is non-operational" do
+      System.put_env("VERISIM_TRANSPORT", "auto")
+      assert Transport.mode() == :auto
+      # No operation is implemented (every NIF/stub returns an error), so the
+      # bridge is non-operational and auto must fall back to HTTP. This is the
+      # guard against silently routing writes into a NIF that does nothing.
+      refute Transport.use_nif?()
+    end
+
+    test "unknown value falls back to :http" do
+      System.put_env("VERISIM_TRANSPORT", "banana")
+      assert Transport.mode() == :http
+    end
+  end
+
+  describe "the NIF bridge never fabricates success (regression for silent data loss)" do
+    test "every operation returns an error tuple, never fake success" do
+      # The previous Rust NIF returned canned success (e.g. delete -> "deleted")
+      # having done nothing. After the fail-loudly fix, the compiled NIF and the
+      # pure-Elixir stub are indistinguishable: both error, neither fabricates.
+      assert {:error, _} = NifBridge.create_octad(~s({"document":{"title":"t","body":"b"}}))
+      assert {:error, _} = NifBridge.get_octad("e-1")
+      assert {:error, _} = NifBridge.delete_octad("e-1")
+      assert {:error, _} = NifBridge.search_text("q", 10)
+      assert {:error, _} = NifBridge.search_vector("[0.1,0.2,0.3]", 5)
+      assert {:error, _} = NifBridge.list_octads(10, 0)
+      assert {:error, _} = NifBridge.get_drift_score("e-1")
+      assert {:error, _} = NifBridge.trigger_normalise("e-1")
+    end
+
+    test "loaded? is false when no operation is operational" do
+      refute NifBridge.loaded?()
+    end
+  end
+
+  describe "health does not fake success under an explicit nif transport" do
+    test "nif health reports not operational, never {:ok, healthy}" do
+      System.put_env("VERISIM_TRANSPORT", "nif")
+      assert {:error, :nif_not_operational} = Transport.health()
+    end
+  end
+end

--- a/rust-core/verisim-nif/src/lib.rs
+++ b/rust-core/verisim-nif/src/lib.rs
@@ -17,7 +17,7 @@
 //! honest stub is the correct behaviour until the store is actually wired in.
 //!
 //! When an operation is implemented, replace its `not_implemented` body with a
-//! real call through the shared [`runtime`]/store; the Elixir transport then
+//! real call through the shared `runtime`/store; the Elixir transport then
 //! observes a real result instead of an error and begins routing to the NIF.
 //!
 //! ## Transport selection (Elixir side)

--- a/rust-core/verisim-nif/src/lib.rs
+++ b/rust-core/verisim-nif/src/lib.rs
@@ -3,41 +3,58 @@
 //!
 //! VeriSimDB NIF Bridge — Erlang/Elixir native interface for direct in-process calls.
 //!
-//! This crate exposes core VeriSimDB operations as Rustler NIFs, bypassing HTTP
-//! for same-node deployments. When used alongside the Elixir orchestration layer,
-//! NIF transport provides 10-100x lower latency than HTTP for octad CRUD operations.
+//! ## Status: SCAFFOLD — no operation is implemented yet
 //!
-//! ## Supported Operations (MVP)
+//! This crate exposes the *shape* of the in-process transport (a Rustler NIF
+//! surface parallel to the HTTP API) but **no operation is wired to the
+//! store**. Every function returns `{:error, :not_implemented}`.
 //!
-//! - `create_octad/1` — Create a new octad entity from JSON input
-//! - `get_octad/1` — Retrieve a octad by ID (all 8 modalities)
-//! - `delete_octad/1` — Delete a octad entity
-//! - `search_text/2` — Full-text search across document modality
-//! - `search_vector/2` — Vector similarity search
-//! - `list_octads/2` — Paginated entity listing
-//! - `get_drift_score/1` — Get drift scores for an entity
-//! - `trigger_normalise/1` — Trigger normalisation for a drifted entity
+//! This is deliberate and load-bearing: an earlier version returned canned
+//! success JSON (e.g. `delete_octad` replied `{"status":"deleted"}` having
+//! deleted nothing). With `VERISIM_TRANSPORT=nif` or `auto` selecting the NIF,
+//! that turned a write into *silent data loss reported as success*. An
+//! unimplemented operation MUST fail loudly, never fake success — so the
+//! honest stub is the correct behaviour until the store is actually wired in.
 //!
-//! ## Transport Selection
+//! When an operation is implemented, replace its `not_implemented` body with a
+//! real call through the shared [`runtime`]/store; the Elixir transport then
+//! observes a real result instead of an error and begins routing to the NIF.
 //!
-//! The Elixir `VeriSim.RustClient` module selects transport via:
-//! ```
+//! ## Transport selection (Elixir side)
+//!
+//! ```text
 //! VERISIM_TRANSPORT=http   # Default: HTTP to verisim-api server
-//! VERISIM_TRANSPORT=nif    # Direct NIF calls (same-node only)
-//! VERISIM_TRANSPORT=auto   # NIF if available, HTTP fallback
+//! VERISIM_TRANSPORT=nif    # Demand NIF: surfaces {:error, :not_implemented} loudly
+//! VERISIM_TRANSPORT=auto   # NIF only if OPERATIONAL, else HTTP — today always HTTP
 //! ```
 
 #![forbid(unsafe_code)]
-use rustler::{Error, NifResult};
-use serde_json::Value;
+use rustler::Atom;
 use std::sync::OnceLock;
 use tokio::runtime::Runtime;
 
+mod atoms {
+    rustler::atoms! {
+        error,
+        not_implemented,
+    }
+}
+
+/// The honest verdict every operation returns until it is wired to the store:
+/// the Elixir term `{:error, :not_implemented}`. Identical in shape to the
+/// pure-Elixir fallback stub's `{:error, :nif_not_loaded}`, so a loaded-but-
+/// unimplemented NIF and an absent NIF are indistinguishable to callers — both
+/// non-operational, neither ever fabricating success.
+#[inline]
+fn not_implemented() -> (Atom, Atom) {
+    (atoms::error(), atoms::not_implemented())
+}
+
 /// Shared Tokio runtime for executing async store operations from synchronous
-/// NIF entry points. Initialised on first NIF call.
+/// NIF entry points. Initialised on first use.
 ///
-/// Currently unused — will be activated when store operations are wired into
-/// the NIF functions (replacing the placeholder responses).
+/// Unused until the first operation is wired to the store (it will drive the
+/// store's async API from these synchronous NIF bodies).
 #[allow(dead_code)]
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
@@ -54,147 +71,61 @@ fn runtime() -> &'static Runtime {
 }
 
 // ---------------------------------------------------------------------------
-// NIF functions
+// NIF functions — all not-yet-implemented; each fails loudly, never fakes.
 // ---------------------------------------------------------------------------
 
-/// Create a new octad entity from a JSON string.
+/// Create a new octad entity from a JSON string. NOT IMPLEMENTED.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn create_octad(_json_input: String) -> (Atom, Atom) {
+    not_implemented()
+}
+
+/// Retrieve a octad by ID. NOT IMPLEMENTED.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn get_octad(_octad_id: String) -> (Atom, Atom) {
+    not_implemented()
+}
+
+/// Delete a octad entity by ID. NOT IMPLEMENTED.
 ///
-/// Accepts a JSON string matching the `OctadInput` schema (same as the HTTP
-/// POST /api/v1/octads body). Returns `{:ok, json_string}` on success or
-/// `{:error, reason}` on failure.
+/// Previously returned `{"status":"deleted"}` without deleting anything — the
+/// silent-data-loss bug this stub exists to prevent.
 #[rustler::nif(schedule = "DirtyCpu")]
-fn create_octad(json_input: String) -> NifResult<String> {
-    let input: Value = serde_json::from_str(&json_input)
-        .map_err(|e| Error::Term(Box::new(format!("invalid JSON: {e}"))))?;
-
-    // Placeholder: in full integration, this calls InMemoryOctadStore::create()
-    // via the shared store instance. For now, return the parsed input as
-    // confirmation that the NIF bridge is functional.
-    let result = serde_json::json!({
-        "status": "created",
-        "input_keys": input.as_object().map(|o| o.keys().collect::<Vec<_>>()).unwrap_or_default(),
-        "transport": "nif"
-    });
-
-    serde_json::to_string(&result)
-        .map_err(|e| Error::Term(Box::new(format!("serialization error: {e}"))))
+fn delete_octad(_octad_id: String) -> (Atom, Atom) {
+    not_implemented()
 }
 
-/// Retrieve a octad by ID.
+/// Full-text search across the document modality. NOT IMPLEMENTED.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn search_text(_query: String, _limit: usize) -> (Atom, Atom) {
+    not_implemented()
+}
+
+/// Vector similarity search. NOT IMPLEMENTED.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn search_vector(_embedding_json: String, _k: usize) -> (Atom, Atom) {
+    not_implemented()
+}
+
+/// Paginated listing of octad entities. NOT IMPLEMENTED.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn list_octads(_limit: usize, _offset: usize) -> (Atom, Atom) {
+    not_implemented()
+}
+
+/// Get drift detection scores for a specific entity. NOT IMPLEMENTED.
 ///
-/// Returns the full octad JSON (all 8 octad modalities) or an error if not found.
+/// Previously returned all-zero scores, indistinguishable from a real
+/// "no drift" measurement — a false negative for the engine's core claim.
 #[rustler::nif(schedule = "DirtyCpu")]
-fn get_octad(octad_id: String) -> NifResult<String> {
-    // Placeholder: will call store.get(&octad_id) via the shared runtime
-    let result = serde_json::json!({
-        "id": octad_id,
-        "status": "nif_placeholder",
-        "transport": "nif",
-        "message": "NIF bridge operational — store integration pending"
-    });
-
-    serde_json::to_string(&result)
-        .map_err(|e| Error::Term(Box::new(format!("serialization error: {e}"))))
+fn get_drift_score(_octad_id: String) -> (Atom, Atom) {
+    not_implemented()
 }
 
-/// Delete a octad entity by ID.
+/// Trigger normalisation (self-repair) for a drifted entity. NOT IMPLEMENTED.
 #[rustler::nif(schedule = "DirtyCpu")]
-fn delete_octad(octad_id: String) -> NifResult<String> {
-    let result = serde_json::json!({
-        "id": octad_id,
-        "status": "deleted",
-        "transport": "nif"
-    });
-
-    serde_json::to_string(&result)
-        .map_err(|e| Error::Term(Box::new(format!("serialization error: {e}"))))
-}
-
-/// Full-text search across the document modality.
-///
-/// Accepts a query string and result limit. Returns a JSON array of matching octads.
-#[rustler::nif(schedule = "DirtyCpu")]
-fn search_text(query: String, limit: usize) -> NifResult<String> {
-    let result = serde_json::json!({
-        "query": query,
-        "limit": limit,
-        "results": [],
-        "transport": "nif"
-    });
-
-    serde_json::to_string(&result)
-        .map_err(|e| Error::Term(Box::new(format!("serialization error: {e}"))))
-}
-
-/// Vector similarity search.
-///
-/// Accepts a JSON-encoded embedding vector and a `k` parameter for top-K results.
-#[rustler::nif(schedule = "DirtyCpu")]
-fn search_vector(embedding_json: String, k: usize) -> NifResult<String> {
-    let _embedding: Vec<f32> = serde_json::from_str(&embedding_json)
-        .map_err(|e| Error::Term(Box::new(format!("invalid embedding JSON: {e}"))))?;
-
-    let result = serde_json::json!({
-        "k": k,
-        "results": [],
-        "transport": "nif"
-    });
-
-    serde_json::to_string(&result)
-        .map_err(|e| Error::Term(Box::new(format!("serialization error: {e}"))))
-}
-
-/// Paginated listing of octad entities.
-#[rustler::nif(schedule = "DirtyCpu")]
-fn list_octads(limit: usize, offset: usize) -> NifResult<String> {
-    let result = serde_json::json!({
-        "limit": limit,
-        "offset": offset,
-        "octads": [],
-        "total": 0,
-        "transport": "nif"
-    });
-
-    serde_json::to_string(&result)
-        .map_err(|e| Error::Term(Box::new(format!("serialization error: {e}"))))
-}
-
-/// Get drift detection scores for a specific entity.
-///
-/// Returns drift scores across all 8 octad modalities (0.0 = no drift, 1.0 = max).
-#[rustler::nif(schedule = "DirtyCpu")]
-fn get_drift_score(octad_id: String) -> NifResult<String> {
-    let result = serde_json::json!({
-        "entity_id": octad_id,
-        "graph": 0.0,
-        "vector": 0.0,
-        "tensor": 0.0,
-        "semantic": 0.0,
-        "document": 0.0,
-        "temporal": 0.0,
-        "provenance": 0.0,
-        "spatial": 0.0,
-        "overall": 0.0,
-        "transport": "nif"
-    });
-
-    serde_json::to_string(&result)
-        .map_err(|e| Error::Term(Box::new(format!("serialization error: {e}"))))
-}
-
-/// Trigger normalisation (self-repair) for a drifted entity.
-///
-/// Returns the normalisation result status.
-#[rustler::nif(schedule = "DirtyCpu")]
-fn trigger_normalise(octad_id: String) -> NifResult<String> {
-    let result = serde_json::json!({
-        "entity_id": octad_id,
-        "status": "normalisation_triggered",
-        "transport": "nif"
-    });
-
-    serde_json::to_string(&result)
-        .map_err(|e| Error::Term(Box::new(format!("serialization error: {e}"))))
+fn trigger_normalise(_octad_id: String) -> (Atom, Atom) {
+    not_implemented()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the sharpest of the remaining honesty leaks — the one whose failure mode is **silent data loss**, not mere overclaiming.

## The tripwire

`verisim-nif` is a scaffold (no operation wired to the store), but every NIF returned **canned success** JSON — `delete_octad` → `{"status":"deleted"}`, `create_octad` → `{"status":"created"}`, `get_drift_score` → all-zeros. When the `.so` is compiled in, `:erlang.load_nif` overrides the honest Elixir fallback stubs with these, `NifBridge.loaded?` reports `true`, and `VERISIM_TRANSPORT=nif` *or* `auto` selects the NIF — so a write returns success **having stored/deleted nothing**. (Without the `.so`, the pure-Elixir stubs already returned `{:error, :nif_not_loaded}`, so the danger lived only in the compiled artifact — which is exactly why no test caught it.)

## The fix — fail loudly, never fake

- **`rust-core/verisim-nif`**: every NIF returns `{:error, :not_implemented}` (rustler atoms). The compiled NIF and the absent-library stub are now **indistinguishable** to callers — both non-operational, both error, neither fabricates. Honest module doc; the dead-code Tokio-runtime scaffold is retained for the eventual real wiring.
- **`nif_bridge.ex`**: `loaded?` redefined to mean **operational** (a probe returns a real binary), so a loaded-but-unimplemented NIF reads as unavailable.
- **`transport.ex`**: `health/0` no longer returns a hardcoded `{:ok, healthy}` under nif — it reports `{:error, :nif_not_operational}` with a warning. `auto` now correctly falls back to HTTP; explicit `nif` surfaces the error.
- **`test/verisim/transport_test.exs`**: regression guard asserting no NIF op ever returns fake success, `auto` won't select a non-operational NIF, and health doesn't fake under nif.
- **KNOWN-ISSUES #28**: documents the fix and frames it as the recurring **silent-fake-success** defect class (cf. #26 drift, #27 scores) that CI scanners structurally cannot catch — it has no dangerous *shape*.

## Verification
Rust: workspace clippy clean under `-D warnings`; `verisim-nif` builds. Elixir: parse + `mix format` clean (full suite runs in CI — `repo.hex.pm` is blocked in this environment, so `mix deps.get` can't run locally; stated plainly rather than simulated).

Note on the broader lesson: this bug is a case study in what the scanners miss. I've held off on a repo-wide "fake-success" lint pending your call on scope (raised in chat) — this PR ships the targeted regression test only.

https://claude.ai/code/session_01E8BpV19yxhf67UrCrvkfTr

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BpV19yxhf67UrCrvkfTr)_