### PR TITLE
refactor(rescript): VCL rename stage B (3/5) — parser, playground, ReScript SDK

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 * @hyperpolymath
 /rust-core/ @hyperpolymath
 /elixir-orchestration/ @hyperpolymath
-/src/vql/ @hyperpolymath
+/src/vcl/ @hyperpolymath
 /container/ @hyperpolymath
 /.github/ @hyperpolymath

--- a/.hypatia-ignore
+++ b/.hypatia-ignore
@@ -2,10 +2,10 @@
 #
 # ReScript (.res) files are permitted in this repository per CLAUDE.md
 # language policy.  ReScript powers:
-#   - src/vql/         — VQL parser, type checker, circuits, subtyping
+#   - src/vcl/         — VCL parser, type checker, circuits, subtyping
 #   - src/registry/    — federation registry (Kraft consensus, metadata log)
 #   - src/abi/         — Idris2/ReScript ABI bridge
-#   - playground/      — VQL Playground web UI
+#   - playground/      — VCL Playground web UI
 #   - connectors/clients/rescript/ — ReScript client SDK
 #
 # Each file is whitelisted by absolute repo path.
@@ -18,7 +18,7 @@ cicd_rules/banned_language_file:connectors/clients/rescript/src/VeriSimHexad.res
 cicd_rules/banned_language_file:connectors/clients/rescript/src/VeriSimProvenance.res
 cicd_rules/banned_language_file:connectors/clients/rescript/src/VeriSimSearch.res
 cicd_rules/banned_language_file:connectors/clients/rescript/src/VeriSimTypes.res
-cicd_rules/banned_language_file:connectors/clients/rescript/src/VeriSimVql.res
+cicd_rules/banned_language_file:connectors/clients/rescript/src/VeriSimVcl.res
 cicd_rules/banned_language_file:debugger/examples/SafeDOMExample.res
 cicd_rules/banned_language_file:examples/SafeDOMExample.res
 cicd_rules/banned_language_file:playground/src/ApiClient.res
@@ -28,22 +28,22 @@ cicd_rules/banned_language_file:playground/src/Examples.res
 cicd_rules/banned_language_file:playground/src/Formatter.res
 cicd_rules/banned_language_file:playground/src/Highlighter.res
 cicd_rules/banned_language_file:playground/src/Linter.res
-cicd_rules/banned_language_file:playground/src/VqlKeywords.res
+cicd_rules/banned_language_file:playground/src/VclKeywords.res
 cicd_rules/banned_language_file:src/registry/KRaftCluster.res
 cicd_rules/banned_language_file:src/registry/KRaftSerializer.res
 cicd_rules/banned_language_file:src/registry/MetadataLog.res
 cicd_rules/banned_language_file:src/registry/Registry.res
-cicd_rules/banned_language_file:src/vql/VQLBidir.res
-cicd_rules/banned_language_file:src/vql/VQLCircuit.res
-cicd_rules/banned_language_file:src/vql/VQLContext.res
-cicd_rules/banned_language_file:src/vql/VQLError.res
-cicd_rules/banned_language_file:src/vql/VQLExplain.res
-cicd_rules/banned_language_file:src/vql/VQLParser.res
-cicd_rules/banned_language_file:src/vql/VQLParser_test.res
-cicd_rules/banned_language_file:src/vql/VQLProofObligation.res
-cicd_rules/banned_language_file:src/vql/VQLSubtyping.res
-cicd_rules/banned_language_file:src/vql/VQLTypeChecker.res
-cicd_rules/banned_language_file:src/vql/VQLTypes.res
+cicd_rules/banned_language_file:src/vcl/VCLBidir.res
+cicd_rules/banned_language_file:src/vcl/VCLCircuit.res
+cicd_rules/banned_language_file:src/vcl/VCLContext.res
+cicd_rules/banned_language_file:src/vcl/VCLError.res
+cicd_rules/banned_language_file:src/vcl/VCLExplain.res
+cicd_rules/banned_language_file:src/vcl/VCLParser.res
+cicd_rules/banned_language_file:src/vcl/VCLParser_test.res
+cicd_rules/banned_language_file:src/vcl/VCLProofObligation.res
+cicd_rules/banned_language_file:src/vcl/VCLSubtyping.res
+cicd_rules/banned_language_file:src/vcl/VCLTypeChecker.res
+cicd_rules/banned_language_file:src/vcl/VCLTypes.res
 
 # verisimdb-registry uses ReScript v11; rescript.json is its build config.
 cicd_rules/banned_config_file:rescript.json

--- a/.machine_readable/contractiles/dust/Dustfile.a2ml
+++ b/.machine_readable/contractiles/dust/Dustfile.a2ml
@@ -60,7 +60,7 @@ nothing is deleted without --apply and per-item approval. Audit trail preserved.
 
 ### no-tracked-rescript-mjs
 - description: No compiled ReScript .res.mjs output tracked in git
-- target: src/vql
+- target: src/vcl
 - reason: Compiled output regenerated from .res sources
 - probe: test -z "$(git ls-files '*.res.mjs' 2>/dev/null)"
 - status: declared

--- a/.machine_readable/contractiles/must/Mustfile.a2ml
+++ b/.machine_readable/contractiles/must/Mustfile.a2ml
@@ -9,7 +9,7 @@
 
 @abstract:
 Physical-state invariants for VeriSimDB — the cross-modal (octad) entity
-consistency engine. Rust core + Elixir/OTP orchestration + ReScript VQL.
+consistency engine. Rust core + Elixir/OTP orchestration + ReScript VCL.
 These are hard requirements: CI and pre-commit hooks fail if any check fails.
 @end
 
@@ -77,11 +77,11 @@ These are hard requirements: CI and pre-commit hooks fail if any check fails.
 - run: test -f .editorconfig
 - severity: warning
 
-## VQL (VeriSim Consonance Language)
+## VCL (VeriSim Consonance Language)
 
-### vql-rescript-parser
-- description: ReScript VQL parser source must exist
-- run: test -d src/vql
+### vcl-rescript-parser
+- description: ReScript VCL parser source must exist
+- run: test -d src/vcl
 - severity: critical
 
 ### vql-elixir-bridge

--- a/connectors/clients/rescript/src/VeriSimError.res
+++ b/connectors/clients/rescript/src/VeriSimError.res
@@ -31,8 +31,8 @@ type t =
   | ModalityUnavailable(string)
   | DriftComputationError(string)
   | ProvenanceInvalid(string)
-  | VqlParseError(string)
-  | VqlExecutionError(string)
+  | VclParseError(string)
+  | VclExecutionError(string)
   | FederationError(string)
   // --- Client-side errors ---
   | ConnectionError(string)
@@ -60,8 +60,8 @@ let message = (err: t): string => {
   | ModalityUnavailable(msg) => `Modality unavailable: ${msg}`
   | DriftComputationError(msg) => `Drift computation error: ${msg}`
   | ProvenanceInvalid(msg) => `Provenance invalid: ${msg}`
-  | VqlParseError(msg) => `VQL parse error: ${msg}`
-  | VqlExecutionError(msg) => `VQL execution error: ${msg}`
+  | VclParseError(msg) => `VCL parse error: ${msg}`
+  | VclExecutionError(msg) => `VCL execution error: ${msg}`
   | FederationError(msg) => `Federation error: ${msg}`
   | ConnectionError(msg) => `Connection error: ${msg}`
   | TimeoutError(msg) => `Timeout error: ${msg}`
@@ -119,8 +119,8 @@ let isRetryable = (err: t): bool => {
   | ModalityUnavailable(_) => false
   | DriftComputationError(_) => false
   | ProvenanceInvalid(_) => false
-  | VqlParseError(_) => false
-  | VqlExecutionError(_) => false
+  | VclParseError(_) => false
+  | VclExecutionError(_) => false
   | FederationError(_) => false
   | SerializationError(_) => false
   | UnknownError(_) => false

--- a/connectors/clients/rescript/src/VeriSimFederation.res
+++ b/connectors/clients/rescript/src/VeriSimFederation.res
@@ -67,7 +67,7 @@ let listPeers = async (
   }
 }
 
-/** Execute a VQL query across one or more federation peers.
+/** Execute a VCL query across one or more federation peers.
  *
  * If peerIds is empty, the query is broadcast to all active peers.
  *

--- a/connectors/clients/rescript/src/VeriSimTypes.res
+++ b/connectors/clients/rescript/src/VeriSimTypes.res
@@ -274,19 +274,19 @@ type searchResult = {
 }
 
 // --------------------------------------------------------------------------
-// VQL types
+// VCL types
 // --------------------------------------------------------------------------
 
-/** Result of a VQL query execution. */
-type vqlResult = {
+/** Result of a VCL query execution. */
+type vclResult = {
   columns: array<string>,
   rows: array<array<string>>,
   count: int,
   elapsedMs: float,
 }
 
-/** Query execution plan explanation for a VQL statement. */
-type vqlExplanation = {
+/** Query execution plan explanation for a VCL statement. */
+type vclExplanation = {
   query: string,
   plan: string,
   cost: float,
@@ -311,7 +311,7 @@ type federationPeer = {
 type peerQueryResult = {
   peerId: string,
   peerName: string,
-  result: vqlResult,
+  result: vclResult,
   elapsedMs: float,
   error: option<string>,
 }

--- a/connectors/clients/rescript/src/VeriSimVcl.res
+++ b/connectors/clients/rescript/src/VeriSimVcl.res
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 //
-// VeriSimDB ReScript Client — VQL (VeriSimDB Query Language) operations.
+// VeriSimDB ReScript Client — VCL (VeriSim Consonance Language) operations.
 //
-// VQL is VeriSimDB's native query language for multi-modal queries that span
+// VCL is VeriSimDB's native consonance language for multi-modal queries that span
 // graph traversals, vector similarity, spatial filters, and temporal constraints
 // in a single statement. This module provides execution and explain functions.
 
-/** VQL request payload for executing or explaining a query. */
-type vqlRequest = {
+/** VCL request payload for executing or explaining a query. */
+type vclRequest = {
   query: string,
   params: Dict.t<string>,
 }
 
-/** Execute a VQL query and return the result set.
+/** Execute a VCL query and return the result set.
  *
  * @param client The authenticated client.
- * @param query The VQL query string.
+ * @param query The VCL query string.
  * @param params Optional named parameters for parameterised queries.
  * @returns The query result with columns, rows, and timing, or an error.
  */
@@ -24,11 +24,11 @@ let execute = async (
   client: VeriSimClient.t,
   query: string,
   ~params: Dict.t<string>=Dict.make(),
-): result<VeriSimTypes.vqlResult, VeriSimError.t> => {
+): result<VeriSimTypes.vclResult, VeriSimError.t> => {
   try {
-    let req: vqlRequest = {query, params}
+    let req: vclRequest = {query, params}
     let body = req->Obj.magic->JSON.stringify->JSON.parseExn
-    let resp = await VeriSimClient.doPost(client, "/api/v1/vql/execute", body)
+    let resp = await VeriSimClient.doPost(client, "/api/v1/vcl/execute", body)
     if resp.ok {
       let json = await VeriSimClient.jsonBody(resp)
       Ok(json->Obj.magic)
@@ -36,14 +36,14 @@ let execute = async (
       Error(VeriSimError.fromStatus(resp.status))
     }
   } catch {
-  | _ => Error(VeriSimError.ConnectionError("VQL execution failed"))
+  | _ => Error(VeriSimError.ConnectionError("VCL execution failed"))
   }
 }
 
-/** Explain a VQL query's execution plan without running it.
+/** Explain a VCL query's execution plan without running it.
  *
  * @param client The authenticated client.
- * @param query The VQL query string.
+ * @param query The VCL query string.
  * @param params Optional named parameters.
  * @returns The query plan, estimated cost, and any warnings, or an error.
  */
@@ -51,11 +51,11 @@ let explain = async (
   client: VeriSimClient.t,
   query: string,
   ~params: Dict.t<string>=Dict.make(),
-): result<VeriSimTypes.vqlExplanation, VeriSimError.t> => {
+): result<VeriSimTypes.vclExplanation, VeriSimError.t> => {
   try {
-    let req: vqlRequest = {query, params}
+    let req: vclRequest = {query, params}
     let body = req->Obj.magic->JSON.stringify->JSON.parseExn
-    let resp = await VeriSimClient.doPost(client, "/api/v1/vql/explain", body)
+    let resp = await VeriSimClient.doPost(client, "/api/v1/vcl/explain", body)
     if resp.ok {
       let json = await VeriSimClient.jsonBody(resp)
       Ok(json->Obj.magic)
@@ -63,6 +63,6 @@ let explain = async (
       Error(VeriSimError.fromStatus(resp.status))
     }
   } catch {
-  | _ => Error(VeriSimError.ConnectionError("VQL explain failed"))
+  | _ => Error(VeriSimError.ConnectionError("VCL explain failed"))
   }
 }

--- a/playground/deno.json
+++ b/playground/deno.json
@@ -1,5 +1,5 @@
 {
-  "name": "vql-playground",
+  "name": "vcl-playground",
   "version": "0.1.0",
   "tasks": {
     "res:build": "rescript",

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vql-playground",
+  "name": "vcl-playground",
   "version": "0.1.0",
-  "description": "VQL Playground — Interactive query editor for VeriSimDB",
+  "description": "VCL Playground — Interactive query editor for VeriSimDB",
   "type": "module",
   "license": "MPL-2.0",
   "author": "Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>",

--- a/playground/public/index.html
+++ b/playground/public/index.html
@@ -4,9 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="VQL Playground — Interactive query editor for VeriSimDB, the octad multimodal database" />
+  <meta name="description" content="VCL Playground — Interactive query editor for VeriSimDB, the octad multimodal database" />
   <meta name="theme-color" content="#3b82f6" />
-  <title>VQL Playground — VeriSimDB</title>
+  <title>VCL Playground — VeriSimDB</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="manifest" href="manifest.json" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -15,15 +15,15 @@
 </head>
 <body>
   <header class="header">
-    <h1><span class="logo">&#9670;</span> VQL Playground</h1>
+    <h1><span class="logo">&#9670;</span> VCL Playground</h1>
     <div class="header-controls">
       <div class="mode-toggle">
-        <label for="vql-dt-toggle">VQL</label>
-        <div class="toggle-switch" id="vql-dt-toggle" role="switch" aria-checked="false" tabindex="0">
+        <label for="vcl-dt-toggle">VCL</label>
+        <div class="toggle-switch" id="vcl-dt-toggle" role="switch" aria-checked="false" tabindex="0">
           <div class="toggle-knob"></div>
         </div>
-        <label for="vql-dt-toggle">VQL-DT</label>
-        <span class="mode-badge vql" id="mode-badge">VQL</span>
+        <label for="vcl-dt-toggle">VCL-DT</label>
+        <span class="mode-badge vcl" id="mode-badge">VCL</span>
       </div>
     </div>
   </header>
@@ -41,7 +41,7 @@
           autocomplete="off"
           autocorrect="off"
           autocapitalize="off"
-          placeholder="-- Enter your VQL query here&#10;SELECT GRAPH, VECTOR&#10;FROM HEXAD&#10;WHERE name = 'example'&#10;LIMIT 10"
+          placeholder="-- Enter your VCL query here&#10;SELECT GRAPH, VECTOR&#10;FROM HEXAD&#10;WHERE name = 'example'&#10;LIMIT 10"
         ></textarea>
       </div>
       <div class="toolbar">
@@ -61,9 +61,9 @@
         <span id="output-format">table</span>
       </div>
       <div id="output">
-<span class="output-info">Welcome to the VQL Playground!
+<span class="output-info">Welcome to the VCL Playground!
 
-VQL (VeriSim Query Language) is the native query interface for VeriSimDB,
+VCL (VeriSim Query Language) is the native query interface for VeriSimDB,
 the octad multimodal database with drift detection and self-normalisation.
 
 Octad modalities: GRAPH, VECTOR, TENSOR, SEMANTIC, DOCUMENT, TEMPORAL, PROVENANCE, SPATIAL
@@ -71,7 +71,7 @@ Octad modalities: GRAPH, VECTOR, TENSOR, SEMANTIC, DOCUMENT, TEMPORAL, PROVENANC
 When verisim-api is running on localhost:8080, queries execute against the real backend.
 Otherwise, demo mode simulates responses offline.
 
-Toggle VQL-DT mode for dependent-type features including:
+Toggle VCL-DT mode for dependent-type features including:
   - PROOF clause (11 types: EXISTENCE, INTEGRITY, CONSISTENCY, PROVENANCE, FRESHNESS, etc.)
   - THRESHOLD constraints
   - Multi-proof composition: PROOF A AND B AND C
@@ -83,7 +83,7 @@ Try an example query or start typing in the editor.</span>
   </main>
 
   <div class="status-bar" id="status-bar">
-    <span id="status-mode">Mode: VQL</span>
+    <span id="status-mode">Mode: VCL</span>
     <span>playground.verisimdb.org</span>
     <span id="status-connection">Demo mode (offline)</span>
   </div>

--- a/playground/public/manifest.json
+++ b/playground/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "VQL Playground",
-  "short_name": "VQL Play",
-  "description": "Interactive VQL query editor for VeriSimDB with VQL-DT mode",
+  "name": "VCL Playground",
+  "short_name": "VCL Play",
+  "description": "Interactive VCL query editor for VeriSimDB with VCL-DT mode",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#0f172a",

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* VQL Playground — Dark theme matching VeriSimDB branding */
+/* VCL Playground — Dark theme matching VeriSimDB branding */
 
 :root {
   --bg-primary: #0f172a;
@@ -69,7 +69,7 @@ body {
   gap: 1rem;
 }
 
-/* VQL-DT Toggle */
+/* VCL-DT Toggle */
 .mode-toggle {
   display: flex;
   align-items: center;
@@ -120,13 +120,13 @@ body {
   letter-spacing: 0.05em;
 }
 
-.mode-badge.vql {
+.mode-badge.vcl {
   background: rgba(59, 130, 246, 0.2);
   color: var(--accent);
   border: 1px solid rgba(59, 130, 246, 0.3);
 }
 
-.mode-badge.vql-dt {
+.mode-badge.vcl-dt {
   background: rgba(196, 181, 253, 0.2);
   color: var(--proof);
   border: 1px solid rgba(196, 181, 253, 0.3);
@@ -344,7 +344,7 @@ body {
   flex-shrink: 0;
 }
 
-.status-bar.vql-dt {
+.status-bar.vcl-dt {
   background: #7c3aed;
 }
 

--- a/playground/public/sw.js
+++ b/playground/public/sw.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
-// Service Worker for VQL Playground PWA — offline support.
+// Service Worker for VCL Playground PWA — offline support.
 
-const CACHE_NAME = "vql-playground-v1";
+const CACHE_NAME = "vcl-playground-v1";
 const ASSETS = ["/", "/index.html", "/app.js", "/style.css", "/manifest.json"];
 
 self.addEventListener("install", (event) => {

--- a/playground/rescript.json
+++ b/playground/rescript.json
@@ -1,5 +1,5 @@
 {
-  "name": "vql-playground",
+  "name": "vcl-playground",
   "sources": [
     {
       "dir": "src",

--- a/playground/src/ApiClient.res
+++ b/playground/src/ApiClient.res
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Playground API client — connects to a real verisim-api backend.
+// VCL Playground API client — connects to a real verisim-api backend.
 // Falls back gracefully to demo mode when the backend is unreachable.
 
-/// Response shape from POST /api/v1/vql/execute.
-type vqlResponse = {
+/// Response shape from POST /api/v1/vcl/execute.
+type vclResponse = {
   success: bool,
   statement_type: string,
   row_count: int,
@@ -54,10 +54,10 @@ let checkHealth = async (): result<string, string> => {
   }
 }
 
-/// Execute a VQL query against the real backend.
-/// Returns Ok(vqlResponse) on success, Error(string) on failure.
-let executeQuery = async (query: string): result<vqlResponse, string> => {
-  let url = getBaseUrl() ++ "/api/v1/vql/execute"
+/// Execute a VCL query against the real backend.
+/// Returns Ok(vclResponse) on success, Error(string) on failure.
+let executeQuery = async (query: string): result<vclResponse, string> => {
+  let url = getBaseUrl() ++ "/api/v1/vcl/execute"
   let bodyDict = Dict.make()
   Dict.set(bodyDict, "query", JSON.Encode.string(query))
   let body = JSON.Encode.object(bodyDict)
@@ -197,8 +197,8 @@ let formatExplainResponse = (data: JSON.t): string => {
   text.contents
 }
 
-/// Convert a VQL response with a JSON data array into a table result.
-let formatAsTable = (response: vqlResponse): DemoExecutor.executeResult => {
+/// Convert a VCL response with a JSON data array into a table result.
+let formatAsTable = (response: vclResponse): DemoExecutor.executeResult => {
   switch JSON.Classify.classify(response.data) {
   | JSON.Classify.Array(items) =>
     if Array.length(items) == 0 {
@@ -258,9 +258,9 @@ let formatAsTable = (response: vqlResponse): DemoExecutor.executeResult => {
   }
 }
 
-/// Convert a VQL API response into a DemoExecutor-compatible result.
+/// Convert a VCL API response into a DemoExecutor-compatible result.
 /// This bridges the real backend response format to the existing rendering code.
-let toExecuteResult = (response: vqlResponse): DemoExecutor.executeResult => {
+let toExecuteResult = (response: vclResponse): DemoExecutor.executeResult => {
   if !response.success {
     DemoExecutor.Error(
       switch response.message {

--- a/playground/src/App.res
+++ b/playground/src/App.res
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Playground — main application entry point.
-// Wires up the editor, VQL-DT toggle, linter, formatter, and query executor.
+// VCL Playground — main application entry point.
+// Wires up the editor, VCL-DT toggle, linter, formatter, and query executor.
 // Tries the real verisim-api backend first, falls back to demo mode.
 
 // === DOM helpers ===
@@ -13,7 +13,7 @@ let addEventListener = (el: {..}, event: string, handler: {..} => unit): unit =>
 
 // === State ===
 
-let vqlDtMode = ref(false)
+let vclDtMode = ref(false)
 let backendConnected = ref(false)
 let queryInFlight = ref(false)
 
@@ -28,30 +28,30 @@ let rec init = () => {
   let statusMode = getElementById("status-mode")
   let statusBar = getElementById("status-bar")
   let statusConnection = getElementById("status-connection")
-  let toggle = getElementById("vql-dt-toggle")
+  let toggle = getElementById("vcl-dt-toggle")
 
   // === Check backend connectivity ===
   checkBackend(statusConnection)->ignore
 
-  // === VQL-DT Toggle ===
+  // === VCL-DT Toggle ===
   let updateMode = () => {
-    if vqlDtMode.contents {
+    if vclDtMode.contents {
       toggle["classList"]["add"]("active")->ignore
-      modeBadge["className"] = "mode-badge vql-dt"
-      modeBadge["textContent"] = "VQL-DT"
-      statusMode["textContent"] = "Mode: VQL-DT (Dependent Types)"
-      statusBar["classList"]["add"]("vql-dt")->ignore
+      modeBadge["className"] = "mode-badge vcl-dt"
+      modeBadge["textContent"] = "VCL-DT"
+      statusMode["textContent"] = "Mode: VCL-DT (Dependent Types)"
+      statusBar["classList"]["add"]("vcl-dt")->ignore
     } else {
       toggle["classList"]["remove"]("active")->ignore
-      modeBadge["className"] = "mode-badge vql"
-      modeBadge["textContent"] = "VQL"
-      statusMode["textContent"] = "Mode: VQL"
-      statusBar["classList"]["remove"]("vql-dt")->ignore
+      modeBadge["className"] = "mode-badge vcl"
+      modeBadge["textContent"] = "VCL"
+      statusMode["textContent"] = "Mode: VCL"
+      statusBar["classList"]["remove"]("vcl-dt")->ignore
     }
   }
 
   addEventListener(toggle, "click", _ => {
-    vqlDtMode := !vqlDtMode.contents
+    vclDtMode := !vclDtMode.contents
     updateMode()->ignore
     // Re-lint current query
     let query = editor["value"]
@@ -65,7 +65,7 @@ let rec init = () => {
     let key: string = e["key"]
     if key == " " || key == "Enter" {
       e["preventDefault"]()
-      vqlDtMode := !vqlDtMode.contents
+      vclDtMode := !vclDtMode.contents
       updateMode()
     }
   })
@@ -128,7 +128,7 @@ let rec init = () => {
   addEventListener(getElementById("lint-btn"), "click", _ => {
     let query: string = editor["value"]
     if String.trim(query) !== "" {
-      let diagnostics = Linter.lint(query, ~vqlDt=vqlDtMode.contents)
+      let diagnostics = Linter.lint(query, ~vclDt=vclDtMode.contents)
       if Array.length(diagnostics) == 0 {
         output["innerHTML"] = `<span class="output-success">No lint issues found.</span>`
       } else {
@@ -151,7 +151,7 @@ let rec init = () => {
   addEventListener(getElementById("format-btn"), "click", _ => {
     let query: string = editor["value"]
     if String.trim(query) !== "" {
-      editor["value"] = Formatter.formatVql(query)
+      editor["value"] = Formatter.formatVcl(query)
       // Trigger input event to update char count
       let inputEvent = document["createEvent"]("Event")
       inputEvent["initEvent"]("input", true, true)->ignore
@@ -167,13 +167,13 @@ let rec init = () => {
   })
 
   addEventListener(getElementById("examples-btn"), "click", _ => {
-    let exs = Examples.forMode(vqlDtMode.contents)
+    let exs = Examples.forMode(vclDtMode.contents)
     let html =
       exs
       ->Array.map(ex => {
         let escaped = String.replaceAll(String.replaceAll(ex.query, "<", "&lt;"), ">", "&gt;")
-        let dtBadge = if ex.vqlDt {
-          ` <span class="mode-badge vql-dt" style="font-size:0.65rem">DT</span>`
+        let dtBadge = if ex.vclDt {
+          ` <span class="mode-badge vcl-dt" style="font-size:0.65rem">DT</span>`
         } else {
           ""
         }
@@ -239,7 +239,7 @@ and executeAndDisplay = (query: string, output: {..}) => {
       executeOnBackend(query, output)->ignore
     } else {
       // Fall back to demo executor (synchronous).
-      let result = DemoExecutor.execute(query, ~vqlDt=vqlDtMode.contents)
+      let result = DemoExecutor.execute(query, ~vclDt=vclDtMode.contents)
       renderResult(result, output)
     }
   }
@@ -268,7 +268,7 @@ and executeOnBackend = async (query: string, output: {..}): unit => {
       `<span class="output-warning">Backend error: ${msg}</span>\n` ++
       `<span class="output-info">Falling back to demo mode...</span>`
     let _ = setTimeout(() => {
-      let result = DemoExecutor.execute(query, ~vqlDt=vqlDtMode.contents)
+      let result = DemoExecutor.execute(query, ~vclDt=vclDtMode.contents)
       renderResult(result, output)
     }, 300)
   }
@@ -322,7 +322,7 @@ and renderResult = (result: DemoExecutor.executeResult, output: {..}) => {
 // === Lint helper ===
 
 and runLint = (query: string, lintBar: {..}) => {
-  let diagnostics = Linter.lint(query, ~vqlDt=vqlDtMode.contents)
+  let diagnostics = Linter.lint(query, ~vclDt=vclDtMode.contents)
   let errors = diagnostics->Array.filter(d => d.severity == Linter.Error)->Array.length
   let warnings = diagnostics->Array.filter(d => d.severity == Linter.Warning)->Array.length
   let hints = diagnostics->Array.filter(d => d.severity == Linter.Hint)->Array.length

--- a/playground/src/DemoExecutor.res
+++ b/playground/src/DemoExecutor.res
@@ -15,13 +15,13 @@ type executeResult =
   | Error(string)
 
 /// Generate demo data based on the query modalities.
-let execute = (query: string, ~vqlDt: bool=false): executeResult => {
+let execute = (query: string, ~vclDt: bool=false): executeResult => {
   let upper = String.toUpperCase(query)
   let startTime = Date.now()
 
   // EXPLAIN mode
   if String.includes(upper, "EXPLAIN") {
-    let modalities = VqlKeywords.modalities->Array.filter(m => String.includes(upper, m))
+    let modalities = VclKeywords.modalities->Array.filter(m => String.includes(upper, m))
     let plan = ref("=== EXPLAIN OUTPUT ===\n\n")
     plan := plan.contents ++ "Strategy: " ++ (if Array.length(modalities) >= 2 { "Parallel" } else { "Sequential" }) ++ "\n\n"
 
@@ -41,7 +41,7 @@ let execute = (query: string, ~vqlDt: bool=false): executeResult => {
       plan := plan.contents ++ `  Selectivity: 0.5\n\n`
     })
 
-    if vqlDt && String.includes(upper, "PROOF") {
+    if vclDt && String.includes(upper, "PROOF") {
       plan := plan.contents ++ "Proof verification: ENABLED\n"
       plan := plan.contents ++ "ZKP scheme: PLONK\n"
       plan := plan.contents ++ "Circuit compilation: deferred\n"
@@ -57,7 +57,7 @@ let execute = (query: string, ~vqlDt: bool=false): executeResult => {
   }
   // SELECT queries — generate demo data
   else if String.includes(upper, "SELECT") {
-    let modalities = VqlKeywords.modalities->Array.filter(m => String.includes(upper, m))
+    let modalities = VclKeywords.modalities->Array.filter(m => String.includes(upper, m))
     if Array.length(modalities) == 0 {
       Error("No modalities specified in SELECT clause")
     } else {
@@ -72,7 +72,7 @@ let execute = (query: string, ~vqlDt: bool=false): executeResult => {
           | "GRAPH" => `{edges: ${Int.toString(3 + i)}, type: "Entity"}`
           | "VECTOR" => `[${Float.toFixed(Float.fromInt(i) *. 0.1, ~digits=2)}, 0.50, 0.30]`
           | "TENSOR" => `shape=[3,3], dtype=f32`
-          | "SEMANTIC" => if vqlDt { `{proof: "verified", scheme: "PLONK"}` } else { `{types: ["Thing"]}` }
+          | "SEMANTIC" => if vclDt { `{proof: "verified", scheme: "PLONK"}` } else { `{types: ["Thing"]}` }
           | "DOCUMENT" => `"Sample document ${Int.toString(i + 1)}"`
           | "TEMPORAL" => `{version: ${Int.toString(i + 1)}, ts: "2026-02-28"}`
           | "PROVENANCE" => `{source: "scan-v1", actor: "hypatia", chain_length: ${Int.toString(i + 1)}}`
@@ -93,6 +93,6 @@ let execute = (query: string, ~vqlDt: bool=false): executeResult => {
       })
     }
   } else {
-    Error("Unrecognized query — VQL queries must start with SELECT, EXPLAIN, INSERT, UPDATE, or DELETE")
+    Error("Unrecognized query — VCL queries must start with SELECT, EXPLAIN, INSERT, UPDATE, or DELETE")
   }
 }

--- a/playground/src/Examples.res
+++ b/playground/src/Examples.res
@@ -1,107 +1,107 @@
 // SPDX-License-Identifier: MPL-2.0
-// Example VQL queries for the playground.
-// Covers all 8 octad modalities, real backend queries, and VQL-DT proof types.
+// Example VCL queries for the playground.
+// Covers all 8 octad modalities, real backend queries, and VCL-DT proof types.
 
 type example = {
   label: string,
   query: string,
-  vqlDt: bool,
+  vclDt: bool,
 }
 
 let examples = [
-  // --- Standard VQL examples ---
+  // --- Standard VCL examples ---
   {
     label: "List all hexads",
     query: "SELECT * FROM hexads LIMIT 10",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Full-text search",
     query: "SEARCH TEXT 'multimodal database' LIMIT 10",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Vector similarity search",
     query: "SEARCH VECTOR [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8] LIMIT 5",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Graph traversal",
     query: "SEARCH RELATED 'entity-1' BY 'relates_to'",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Insert a hexad",
     query: "INSERT INTO hexads (title, body)\nVALUES ('My Entity', 'A multimodal entity in VeriSimDB')",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Show server status",
     query: "SHOW STATUS",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Show drift metrics",
     query: "SHOW DRIFT",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Explain a query",
     query: "EXPLAIN SELECT * FROM hexads WHERE id = 'my-entity' LIMIT 1",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Count hexads",
     query: "COUNT hexads",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Multi-modality query (demo)",
     query: "SELECT GRAPH, VECTOR, DOCUMENT, PROVENANCE\nFROM HEXAD\nWHERE name CONTAINS 'example'\nORDER BY score DESC\nLIMIT 20",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Temporal query (demo)",
     query: "SELECT TEMPORAL, PROVENANCE\nFROM HEXAD\nAT TIME '2026-02-28T00:00:00Z'\nWHERE id = 'entity-123'\nLIMIT 1",
-    vqlDt: false,
+    vclDt: false,
   },
   {
     label: "Federation query (demo)",
     query: "SELECT GRAPH\nFROM FEDERATION STORE 'remote-cluster-1'\nHEXAD\nWHERE region = 'eu-west'\nLIMIT 25",
-    vqlDt: false,
+    vclDt: false,
   },
-  // --- VQL-DT examples ---
+  // --- VCL-DT examples ---
   {
-    label: "Proof of existence (VQL-DT)",
+    label: "Proof of existence (VCL-DT)",
     query: "SELECT SEMANTIC\nFROM HEXAD\nPROOF EXISTENCE\nTHRESHOLD 0.95\nWHERE type = 'Certificate'\nLIMIT 10",
-    vqlDt: true,
+    vclDt: true,
   },
   {
-    label: "Integrity proof (VQL-DT)",
+    label: "Integrity proof (VCL-DT)",
     query: "SELECT SEMANTIC, DOCUMENT\nFROM HEXAD\nPROOF INTEGRITY\nTHRESHOLD 0.99\nWHERE classification = 'audit-trail'\nLIMIT 5",
-    vqlDt: true,
+    vclDt: true,
   },
   {
-    label: "Consistency check (VQL-DT)",
+    label: "Consistency check (VCL-DT)",
     query: "SELECT GRAPH, SEMANTIC\nFROM HEXAD\nPROOF CONSISTENCY\nTHRESHOLD 0.9\nWHERE DRIFT THRESHOLD 0.1\nLIMIT 20",
-    vqlDt: true,
+    vclDt: true,
   },
   {
-    label: "Provenance proof (VQL-DT)",
+    label: "Provenance proof (VCL-DT)",
     query: "SELECT PROVENANCE, SEMANTIC\nFROM HEXAD\nPROOF PROVENANCE\nTHRESHOLD 0.95\nWHERE source = 'verified-origin'\nLIMIT 10",
-    vqlDt: true,
+    vclDt: true,
   },
   {
-    label: "Freshness proof (VQL-DT)",
+    label: "Freshness proof (VCL-DT)",
     query: "SELECT TEMPORAL, SEMANTIC\nFROM HEXAD\nPROOF FRESHNESS\nTHRESHOLD 0.99\nWHERE age_ms < 86400000\nLIMIT 10",
-    vqlDt: true,
+    vclDt: true,
   },
   {
-    label: "Multi-proof composition (VQL-DT)",
+    label: "Multi-proof composition (VCL-DT)",
     query: "SELECT SEMANTIC, PROVENANCE, TEMPORAL\nFROM HEXAD\nPROOF EXISTENCE AND INTEGRITY AND FRESHNESS\nTHRESHOLD 0.95\nWHERE type = 'critical-entity'\nLIMIT 5",
-    vqlDt: true,
+    vclDt: true,
   },
 ]
 
-let forMode = (vqlDt: bool): array<example> =>
-  examples->Array.filter(e => !e.vqlDt || vqlDt)
+let forMode = (vclDt: bool): array<example> =>
+  examples->Array.filter(e => !e.vclDt || vclDt)

--- a/playground/src/Formatter.res
+++ b/playground/src/Formatter.res
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL formatter — canonical formatting for queries.
+// VCL formatter — canonical formatting for queries.
 
 /// Clause-starting keywords that get their own line.
 let clauseStarters = [
@@ -8,7 +8,7 @@ let clauseStarters = [
   "TRAVERSE", "PROOF", "EXPLAIN",
 ]
 
-let formatVql = (query: string): string => {
+let formatVcl = (query: string): string => {
   let upper = String.toUpperCase
   let tokens =
     String.splitByRe(query, %re("/(\s+|'[^']*'|\"[^\"]*\")/"))
@@ -30,7 +30,7 @@ let formatVql = (query: string): string => {
       result := result.contents ++ trimmed
     } else {
       let word = upper(trimmed)
-      let formatted = if VqlKeywords.isKeyword(word) || VqlKeywords.isModality(word) {
+      let formatted = if VclKeywords.isKeyword(word) || VclKeywords.isModality(word) {
         word
       } else {
         trimmed

--- a/playground/src/Highlighter.res
+++ b/playground/src/Highlighter.res
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL syntax highlighting for the playground editor.
+// VCL syntax highlighting for the playground editor.
 // Produces HTML spans with CSS classes for keyword colouring.
 
-let highlightVql = (text: string, ~vqlDt: bool=false): string => {
+let highlightVcl = (text: string, ~vclDt: bool=false): string => {
   let result = ref("")
   let chars = String.split(text, "")
   let len = Array.length(chars)
@@ -46,11 +46,11 @@ let highlightVql = (text: string, ~vqlDt: bool=false): string => {
       let word = String.slice(text, ~start, ~end=i.contents)
       let upper = String.toUpperCase(word)
 
-      if VqlKeywords.isModality(upper) {
+      if VclKeywords.isModality(upper) {
         result := result.contents ++ `<span class="mod">${word}</span>`
-      } else if VqlKeywords.isProofType(upper) && vqlDt {
+      } else if VclKeywords.isProofType(upper) && vclDt {
         result := result.contents ++ `<span class="proof">${word}</span>`
-      } else if VqlKeywords.isKeyword(upper) {
+      } else if VclKeywords.isKeyword(upper) {
         result := result.contents ++ `<span class="kw">${word}</span>`
       } else {
         result := result.contents ++ word

--- a/playground/src/Linter.res
+++ b/playground/src/Linter.res
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL client-side linter — mirrors the Rust linter rules (VQL001–VQL011).
+// VCL client-side linter — mirrors the Rust linter rules (VCL001–VCL011).
 
 type severity = Hint | Warning | Error
 
@@ -16,7 +16,7 @@ let severityToString = s =>
   | Error => "error"
   }
 
-let lint = (query: string, ~vqlDt: bool=false): array<diagnostic> => {
+let lint = (query: string, ~vclDt: bool=false): array<diagnostic> => {
   let diagnostics = []
   let upper = String.toUpperCase(query)
   let tokens =
@@ -30,98 +30,98 @@ let lint = (query: string, ~vqlDt: bool=false): array<diagnostic> => {
   let isUpdate = has("UPDATE")
   let isExplain = has("EXPLAIN")
 
-  // VQL001: Missing LIMIT
+  // VCL001: Missing LIMIT
   if isSelect && !has("LIMIT") && !isExplain {
     diagnostics->Array.push({
-      code: "VQL001",
+      code: "VCL001",
       severity: Warning,
       message: "Query lacks LIMIT clause — may return unbounded results",
     })
   }
 
-  // VQL002: SELECT all modalities
+  // VCL002: SELECT all modalities
   if isSelect {
     let count =
-      VqlKeywords.modalities->Array.filter(m => has(m))->Array.length
+      VclKeywords.modalities->Array.filter(m => has(m))->Array.length
     if count >= 6 {
       diagnostics->Array.push({
-        code: "VQL002",
+        code: "VCL002",
         severity: Hint,
         message: "Query selects " ++ Int.toString(count) ++ " of 8 modalities — consider selecting only what you need",
       })
     }
   }
 
-  // VQL003: Semantic without PROOF
+  // VCL003: Semantic without PROOF
   if has("SEMANTIC") && !has("PROOF") && isSelect {
     diagnostics->Array.push({
-      code: "VQL003",
-      severity: if vqlDt { Error } else { Warning },
+      code: "VCL003",
+      severity: if vclDt { Error } else { Warning },
       message: "Semantic modality accessed without PROOF clause",
     })
   }
 
-  // VQL004: TRAVERSE without DEPTH
+  // VCL004: TRAVERSE without DEPTH
   if has("TRAVERSE") && !has("DEPTH") {
     diagnostics->Array.push({
-      code: "VQL004",
+      code: "VCL004",
       severity: Error,
       message: "TRAVERSE without DEPTH limit — may explore entire graph",
     })
   }
 
-  // VQL005: DRIFT without THRESHOLD
+  // VCL005: DRIFT without THRESHOLD
   if (has("DRIFT") || has("CONSISTENCY")) && !has("THRESHOLD") {
     diagnostics->Array.push({
-      code: "VQL005",
+      code: "VCL005",
       severity: Hint,
       message: "DRIFT/CONSISTENCY check without THRESHOLD — using implicit default",
     })
   }
 
-  // VQL006: ORDER BY without LIMIT
+  // VCL006: ORDER BY without LIMIT
   if has("ORDER") && !has("LIMIT") && isSelect {
     diagnostics->Array.push({
-      code: "VQL006",
+      code: "VCL006",
       severity: Warning,
       message: "ORDER BY without LIMIT — sorting potentially unbounded result set",
     })
   }
 
-  // VQL007: Dangerous write without WHERE
+  // VCL007: Dangerous write without WHERE
   if (isDelete || isUpdate) && !has("WHERE") {
     diagnostics->Array.push({
-      code: "VQL007",
+      code: "VCL007",
       severity: Error,
       message: "DELETE/UPDATE without WHERE clause — affects all entities",
     })
   }
 
-  // VQL010: Multi-modality without EXPLAIN
+  // VCL010: Multi-modality without EXPLAIN
   if isSelect && !isExplain {
     let count =
-      VqlKeywords.modalities->Array.filter(m => has(m))->Array.length
+      VclKeywords.modalities->Array.filter(m => has(m))->Array.length
     if count >= 3 {
       diagnostics->Array.push({
-        code: "VQL010",
+        code: "VCL010",
         severity: Hint,
         message: "Multi-modality query — consider running EXPLAIN first",
       })
     }
   }
 
-  // VQL011: FEDERATION without STORE
+  // VCL011: FEDERATION without STORE
   if has("FEDERATION") && !has("STORE") {
     diagnostics->Array.push({
-      code: "VQL011",
+      code: "VCL011",
       severity: Warning,
       message: "FEDERATION query without STORE — will query all federated instances",
     })
   }
 
-  // VQL-DT specific: PROOF required for all semantic access
-  if vqlDt && isSelect && has("SEMANTIC") && !has("PROOF") {
-    // Already covered by VQL003 with Error severity
+  // VCL-DT specific: PROOF required for all semantic access
+  if vclDt && isSelect && has("SEMANTIC") && !has("PROOF") {
+    // Already covered by VCL003 with Error severity
     ignore()
   }
 

--- a/playground/src/VclKeywords.res
+++ b/playground/src/VclKeywords.res
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL keyword definitions shared across syntax highlighting, completion, and linting.
+// VCL keyword definitions shared across syntax highlighting, completion, and linting.
 // Updated for the octad architecture (8 modalities) and 11 proof types.
 
 let keywords = [
@@ -20,15 +20,15 @@ let modalities = [
   "PROVENANCE", "SPATIAL",
 ]
 
-/// All 11 proof types supported by the VQL-DT type checker.
+/// All 11 proof types supported by the VCL-DT type checker.
 let proofTypes = [
   "EXISTENCE", "CONSISTENCY", "INTEGRITY", "PROVENANCE",
   "FRESHNESS", "ACCESS", "CITATION", "CUSTOM",
   "ZKP", "PROVEN", "SANCTIFY",
 ]
 
-/// VQL-DT specific keywords (only active in VQL-DT mode).
-let vqlDtKeywords = [
+/// VCL-DT specific keywords (only active in VCL-DT mode).
+let vclDtKeywords = [
   "PROOF", "THRESHOLD", "VERIFY", "CERTIFY", "ATTEST",
   "WITNESS", "CIRCUIT", "COMMITMENT",
 ]

--- a/src/vcl/VCLBidir.res
+++ b/src/vcl/VCLBidir.res
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Bidirectional Type Inference
+// VCL Bidirectional Type Inference
 //
-// Implements bidirectional type checking for VQL queries:
+// Implements bidirectional type checking for VCL queries:
 // - synthesize: infer the type of a query from its structure
 // - check: verify a query expression has an expected type
 //
@@ -9,17 +9,17 @@
 // verifying that all field references, operators, aggregates, and
 // proof obligations are well-typed.
 
-module AST = VQLParser.AST
-module Types = VQLTypes
-module Ctx = VQLContext
-module Sub = VQLSubtyping
+module AST = VCLParser.AST
+module Types = VCLTypes
+module Ctx = VCLContext
+module Sub = VCLSubtyping
 
 // ============================================================================
 // Type Error
 // ============================================================================
 
 type typeError =
-  | SubtypingFailed({expected: Types.vqlType, got: Types.vqlType, reason: string})
+  | SubtypingFailed({expected: Types.vclType, got: Types.vclType, reason: string})
   | FieldTypeMismatch({field: string, expected: Types.primitiveType, got: Types.primitiveType})
   | OperatorTypeMismatch({op: string, leftType: Types.primitiveType, rightType: Types.primitiveType})
   | VectorDimensionMismatch({expected: int, got: int})
@@ -49,7 +49,7 @@ type typeError =
 let formatTypeError = (err: typeError): string => {
   switch err {
   | SubtypingFailed({expected, got, reason}) =>
-    `Subtyping failed: expected ${Types.vqlTypeToString(expected)}, got ${Types.vqlTypeToString(got)}: ${reason}`
+    `Subtyping failed: expected ${Types.vclTypeToString(expected)}, got ${Types.vclTypeToString(got)}: ${reason}`
   | FieldTypeMismatch({field, expected, got}) =>
     `Field '${field}' type mismatch: expected ${Types.primitiveTypeToString(expected)}, got ${Types.primitiveTypeToString(got)}`
   | OperatorTypeMismatch({op, leftType, rightType}) =>
@@ -87,7 +87,7 @@ let formatTypeError = (err: typeError): string => {
 // Synthesize: Infer type of a complete query
 // ============================================================================
 
-type synthesizeResult = Result<Types.vqlType, typeError>
+type synthesizeResult = Result<Types.vclType, typeError>
 
 let synthesizeQuery = (ctx: Ctx.context, query: AST.query): synthesizeResult => {
   // 1. Resolve modalities to type-level representations
@@ -160,7 +160,7 @@ let synthesizeQuery = (ctx: Ctx.context, query: AST.query): synthesizeResult => 
 let checkQuery = (
   ctx: Ctx.context,
   query: AST.query,
-  expectedType: Types.vqlType,
+  expectedType: Types.vclType,
 ): Result<unit, typeError> => {
   switch synthesizeQuery(ctx, query) {
   | Error(e) => Error(e)

--- a/src/vcl/VCLCircuit.res
+++ b/src/vcl/VCLCircuit.res
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Circuit DSL — Defines types for custom ZKP circuits in VQL.
+// VCL Circuit DSL — Defines types for custom ZKP circuits in VCL.
 //
-// Usage in VQL:
+// Usage in VCL:
 //   PROOF CUSTOM "circuit-name" WITH (threshold=0.5, min_score=0.1)
 
 /// Gate types available in custom circuits
@@ -34,7 +34,7 @@ type constraint = {
   c: array<(int, float)>,
 }
 
-/// A circuit definition from VQL PROOF CUSTOM clause
+/// A circuit definition from VCL PROOF CUSTOM clause
 type circuitDef = {
   name: string,
   wires: array<wire>,
@@ -42,7 +42,7 @@ type circuitDef = {
   parameters: array<string>,
 }
 
-/// Parameters passed via VQL WITH clause
+/// Parameters passed via VCL WITH clause
 type circuitParams = {
   values: Js.Dict.t<string>,
 }
@@ -56,7 +56,7 @@ type verificationResult = {
   totalConstraints: int,
 }
 
-/// Parse a PROOF CUSTOM clause from VQL
+/// Parse a PROOF CUSTOM clause from VCL
 let parseCustomProof = (circuitName: string, withParams: array<(string, string)>): (string, circuitParams) => {
   let dict = Js.Dict.empty()
   withParams->Array.forEach(((key, value)) => {

--- a/src/vcl/VCLContext.res
+++ b/src/vcl/VCLContext.res
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Context — Typing environment for bidirectional type checking
+// VCL Context — Typing environment for bidirectional type checking
 //
 // Maintains bindings, contract registry, modality field registries,
 // and store capabilities.
 
-module Types = VQLTypes
+module Types = VCLTypes
 
 // ============================================================================
 // Contract Specification
@@ -32,7 +32,7 @@ type fieldEntry = {
 // ============================================================================
 
 type context = {
-  bindings: Js.Dict.t<Types.vqlType>,
+  bindings: Js.Dict.t<Types.vclType>,
   contracts: Js.Dict.t<contractSpec>,
   modalityFields: Js.Dict.t<array<fieldEntry>>,
   storeModalities: Js.Dict.t<array<Types.modalityType>>,
@@ -139,13 +139,13 @@ let defaultContext = (): context => {
 // Lookup operations
 // ============================================================================
 
-let bind = (ctx: context, name: string, ty: Types.vqlType): context => {
+let bind = (ctx: context, name: string, ty: Types.vclType): context => {
   let newBindings = Js.Dict.fromArray(Js.Dict.entries(ctx.bindings))
   Js.Dict.set(newBindings, name, ty)
   {...ctx, bindings: newBindings}
 }
 
-let lookup = (ctx: context, name: string): option<Types.vqlType> => {
+let lookup = (ctx: context, name: string): option<Types.vclType> => {
   Js.Dict.get(ctx.bindings, name)
 }
 

--- a/src/vcl/VCLError.res
+++ b/src/vcl/VCLError.res
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 /**
- * VQL Error Types - Structured error representation
+ * VCL Error Types - Structured error representation
  *
- * Provides comprehensive error types for all VQL failure modes:
+ * Provides comprehensive error types for all VCL failure modes:
  * - Parse errors (syntax)
  * - Type errors (dependent-type verification)
  * - Runtime errors (execution)
@@ -194,13 +194,13 @@ type federationError = {
 // Composite Error Type
 // ============================================================================
 
-type vqlError =
+type vclError =
   | ParseError(parseError)
   | TypeError(typeError)
   | RuntimeError(runtimeError)
   | ModalityError(modalityError)
   | FederationError(federationError)
-  | MultipleErrors(array<vqlError>)
+  | MultipleErrors(array<vclError>)
 
 // ============================================================================
 // Error Formatting
@@ -398,7 +398,7 @@ let formatFederationError = (err: federationError): string => {
   `Federation Error [${err.federation_pattern}]: ${kindStr}`
 }
 
-let format = (err: vqlError): string => {
+let format = (err: vclError): string => {
   switch err {
   | ParseError(e) => formatParseError(e)
   | TypeError(e) => formatTypeError(e)
@@ -419,7 +419,7 @@ let format = (err: vqlError): string => {
 // Error Helpers
 // ============================================================================
 
-let isRecoverable = (err: vqlError): bool => {
+let isRecoverable = (err: vclError): bool => {
   switch err {
   | RuntimeError(e) => e.recoverable
   | FederationError({kind: PartialResults(_)}) => true
@@ -428,28 +428,28 @@ let isRecoverable = (err: vqlError): bool => {
   }
 }
 
-let getErrorCode = (err: vqlError): string => {
+let getErrorCode = (err: vclError): string => {
   switch err {
-  | ParseError(_) => "VQL_PARSE_ERROR"
-  | TypeError(_) => "VQL_TYPE_ERROR"
-  | RuntimeError({kind: StoreUnavailable(_)}) => "VQL_STORE_UNAVAILABLE"
-  | RuntimeError({kind: QueryTimeout(_)}) => "VQL_QUERY_TIMEOUT"
-  | RuntimeError({kind: DriftDetected(_)}) => "VQL_DRIFT_DETECTED"
-  | RuntimeError({kind: PermissionDenied(_)}) => "VQL_PERMISSION_DENIED"
-  | RuntimeError({kind: ResourceExhausted(_)}) => "VQL_RESOURCE_EXHAUSTED"
-  | RuntimeError(_) => "VQL_RUNTIME_ERROR"
-  | ModalityError(GraphError(_)) => "VQL_GRAPH_ERROR"
-  | ModalityError(VectorError(_)) => "VQL_VECTOR_ERROR"
-  | ModalityError(TensorError(_)) => "VQL_TENSOR_ERROR"
-  | ModalityError(SemanticError(_)) => "VQL_SEMANTIC_ERROR"
-  | ModalityError(DocumentError(_)) => "VQL_DOCUMENT_ERROR"
-  | ModalityError(TemporalError(_)) => "VQL_TEMPORAL_ERROR"
-  | FederationError(_) => "VQL_FEDERATION_ERROR"
-  | MultipleErrors(_) => "VQL_MULTIPLE_ERRORS"
+  | ParseError(_) => "VCL_PARSE_ERROR"
+  | TypeError(_) => "VCL_TYPE_ERROR"
+  | RuntimeError({kind: StoreUnavailable(_)}) => "VCL_STORE_UNAVAILABLE"
+  | RuntimeError({kind: QueryTimeout(_)}) => "VCL_QUERY_TIMEOUT"
+  | RuntimeError({kind: DriftDetected(_)}) => "VCL_DRIFT_DETECTED"
+  | RuntimeError({kind: PermissionDenied(_)}) => "VCL_PERMISSION_DENIED"
+  | RuntimeError({kind: ResourceExhausted(_)}) => "VCL_RESOURCE_EXHAUSTED"
+  | RuntimeError(_) => "VCL_RUNTIME_ERROR"
+  | ModalityError(GraphError(_)) => "VCL_GRAPH_ERROR"
+  | ModalityError(VectorError(_)) => "VCL_VECTOR_ERROR"
+  | ModalityError(TensorError(_)) => "VCL_TENSOR_ERROR"
+  | ModalityError(SemanticError(_)) => "VCL_SEMANTIC_ERROR"
+  | ModalityError(DocumentError(_)) => "VCL_DOCUMENT_ERROR"
+  | ModalityError(TemporalError(_)) => "VCL_TEMPORAL_ERROR"
+  | FederationError(_) => "VCL_FEDERATION_ERROR"
+  | MultipleErrors(_) => "VCL_MULTIPLE_ERRORS"
   }
 }
 
-let toJson = (err: vqlError): Js.Json.t => {
+let toJson = (err: vclError): Js.Json.t => {
   Js.Dict.fromArray([
     ("error_code", Js.Json.string(getErrorCode(err))),
     ("message", Js.Json.string(format(err))),

--- a/src/vcl/VCLExplain.res
+++ b/src/vcl/VCLExplain.res
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL EXPLAIN - Query Plan Visualization
+// VCL EXPLAIN - Query Plan Visualization
 
-module AST = VQLParser.AST
+module AST = VCLParser.AST
 
 type planNode = {
   step: int,
@@ -46,7 +46,7 @@ let formatPlan = (plan: executionPlan): string => {
 
   // Header
   lines->Js.Array2.push("╔════════════════════════════════════════════════════════════════╗")
-  lines->Js.Array2.push("║              VQL QUERY EXECUTION PLAN                          ║")
+  lines->Js.Array2.push("║              VCL QUERY EXECUTION PLAN                          ║")
   lines->Js.Array2.push("╚════════════════════════════════════════════════════════════════╝")
   lines->Js.Array2.push("")
 
@@ -183,7 +183,7 @@ let explainQuery = (query: string): Result<string, string> => {
   switch parseExplain(query) {
   | Ok((true, actualQuery)) => {
       // Parse the query
-      switch VQLParser.parse(actualQuery) {
+      switch VCLParser.parse(actualQuery) {
       | Ok(ast) => {
           // Generate plan (this would call Elixir QueryPlanner)
           let plan = generatePlanFromAst(ast)
@@ -198,7 +198,7 @@ let explainQuery = (query: string): Result<string, string> => {
 }
 
 // Generate plan based on actual AST analysis (replaces hardcoded mock)
-let generatePlanFromAst = (ast: VQLParser.query): executionPlan => {
+let generatePlanFromAst = (ast: VCLParser.query): executionPlan => {
   let nodes = ast.modalities->Belt.Array.mapWithIndex((idx, modality) => {
     let modalityStr = switch modality {
     | Graph => "GRAPH"
@@ -383,7 +383,7 @@ let generatePlanFromAst = (ast: VQLParser.query): executionPlan => {
 }
 
 // Deprecated: Use generatePlanFromAst instead. Kept for test compatibility only.
-let generateMockPlan = (ast: VQLParser.query): executionPlan => {
+let generateMockPlan = (ast: VCLParser.query): executionPlan => {
   let nodes = ast.modalities->Belt.Array.mapWithIndex((idx, modality) => {
     let modalityStr = switch modality {
     | Graph => "GRAPH"

--- a/src/vcl/VCLParser.res
+++ b/src/vcl/VCLParser.res
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Slipstream Parser - Untyped AST
+// VCL Slipstream Parser - Untyped AST
 // Phase 1: Simple parser for slipstream queries (no dependent types)
 
 // ============================================================================
@@ -353,7 +353,7 @@ module Parser = {
 }
 
 // ============================================================================
-// VQL Grammar Parsers
+// VCL Grammar Parsers
 // ============================================================================
 
 module Grammar = {

--- a/src/vcl/VCLParser_test.res
+++ b/src/vcl/VCLParser_test.res
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Parser Tests
+// VCL Parser Tests
 
-open VQLParser
+open VCLParser
 
 // Test helper
 let assertOk = (result: Result<'a, 'b>, testName: string) => {
@@ -22,7 +22,7 @@ let assertError = (result: Result<'a, 'b>, testName: string) => {
 // Test Suite
 // ============================================================================
 
-Js.Console.log("\n=== VQL Parser Tests ===\n")
+Js.Console.log("\n=== VCL Parser Tests ===\n")
 
 // Test 1: Simple hexad query
 let test1 = `

--- a/src/vcl/VCLProofObligation.res
+++ b/src/vcl/VCLProofObligation.res
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Proof Obligation — Generates typed proof obligations from queries
+// VCL Proof Obligation — Generates typed proof obligations from queries
 //
 // For each PROOF spec in a dependent-type query, generates a structured
 // obligation that the executor must satisfy. Handles multi-proof
 // composition validation and conflict detection.
 
-module AST = VQLParser.AST
-module Types = VQLTypes
-module Ctx = VQLContext
+module AST = VCLParser.AST
+module Types = VCLTypes
+module Ctx = VCLContext
 
 // ============================================================================
 // Proof Obligation Types

--- a/src/vcl/VCLSubtyping.res
+++ b/src/vcl/VCLSubtyping.res
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Subtyping — Subtype relation for the VQL type system
+// VCL Subtyping — Subtype relation for the VCL type system
 //
 // Implements the 6 subtyping rules from the formal spec (Section 4):
 // 1. Reflexivity: t <: t
@@ -9,13 +9,13 @@
 // 5. Hexad modality contravariance: requesting fewer modalities subtypes requesting more
 // 6. Refinement subsumption: DEFERRED (needs SMT solver)
 
-module Types = VQLTypes
+module Types = VCLTypes
 
 type subtypeResult = Result<unit, subtypeError>
 
 and subtypeError = {
-  expected: Types.vqlType,
-  got: Types.vqlType,
+  expected: Types.vclType,
+  got: Types.vclType,
   reason: string,
 }
 
@@ -37,7 +37,7 @@ let isSubPrimitive = (sub: Types.primitiveType, sup: Types.primitiveType): bool 
 // Core subtype relation
 // ============================================================================
 
-let rec isSubtype = (sub: Types.vqlType, sup: Types.vqlType): subtypeResult => {
+let rec isSubtype = (sub: Types.vclType, sup: Types.vclType): subtypeResult => {
   // Rule 1: Reflexivity
   if Types.eqType(sub, sup) {
     Ok()
@@ -46,7 +46,7 @@ let rec isSubtype = (sub: Types.vqlType, sup: Types.vqlType): subtypeResult => {
   }
 }
 
-and checkStructuralSubtype = (sub: Types.vqlType, sup: Types.vqlType): subtypeResult => {
+and checkStructuralSubtype = (sub: Types.vclType, sup: Types.vclType): subtypeResult => {
   switch (sub, sup) {
   // Primitive widening
   | (Primitive(ps), Primitive(pp)) =>
@@ -145,7 +145,7 @@ and checkStructuralSubtype = (sub: Types.vqlType, sup: Types.vqlType): subtypeRe
     Error({
       expected: sup,
       got: sub,
-      reason: `${Types.vqlTypeToString(sub)} is not a subtype of ${Types.vqlTypeToString(sup)}`,
+      reason: `${Types.vclTypeToString(sub)} is not a subtype of ${Types.vclTypeToString(sup)}`,
     })
   }
 }
@@ -178,9 +178,9 @@ and isSubQueryResult = (
 // ============================================================================
 
 let transitiveSubtype = (
-  a: Types.vqlType,
-  b: Types.vqlType,
-  c: Types.vqlType,
+  a: Types.vclType,
+  b: Types.vclType,
+  c: Types.vclType,
 ): subtypeResult => {
   switch isSubtype(a, b) {
   | Ok() =>
@@ -209,7 +209,7 @@ let transitiveSubtype = (
 // Given two types and an operator, check if comparison is valid
 let checkOperatorTypes = (
   leftType: Types.primitiveType,
-  op: VQLParser.AST.operator,
+  op: VCLParser.AST.operator,
   rightType: Types.primitiveType,
 ): subtypeResult => {
   // Types must be compatible (one subtype of the other, or same)

--- a/src/vcl/VCLTypeChecker.res
+++ b/src/vcl/VCLTypeChecker.res
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Type Checker — Thin facade over VQLBidir bidirectional type inference
+// VCL Type Checker — Thin facade over VCLBidir bidirectional type inference
 //
 // Maintains backward-compatible public API (checkQuery, planProofGeneration)
-// while delegating to the real type system in VQLBidir.
+// while delegating to the real type system in VCLBidir.
 
-module AST = VQLParser.AST
-module Error = VQLError
-module Types = VQLTypes
-module Ctx = VQLContext
-module Bidir = VQLBidir
-module ProofObl = VQLProofObligation
+module AST = VCLParser.AST
+module Error = VCLError
+module Types = VCLTypes
+module Ctx = VCLContext
+module Bidir = VCLBidir
+module ProofObl = VCLProofObligation
 
 // ============================================================================
 // Type Context (backward-compatible)
@@ -113,7 +113,7 @@ let checkQuery = (query: AST.query, context: typeContext): typeCheckResult => {
     switch Bidir.synthesizeQuery(bidirCtx, query) {
     | Ok(_type) => Ok()
     | Error(typeErr) =>
-      // Convert Bidir.typeError to VQLError.typeError
+      // Convert Bidir.typeError to VCLError.typeError
       Error({
         kind: Error.TypeMismatch({
           expected: "well-typed query",

--- a/src/vcl/VCLTypes.res
+++ b/src/vcl/VCLTypes.res
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// VQL Types — Core type definitions for the bidirectional type checker
+// VCL Types — Core type definitions for the bidirectional type checker
 //
 // Implements the type system from vcl-type-system.adoc:
 // - Pi types (dependent function types)
@@ -9,7 +9,7 @@
 // - Query result types
 // - Proof types
 
-module AST = VQLParser.AST
+module AST = VCLParser.AST
 
 // ============================================================================
 // Modality Types (type-level representation)
@@ -40,19 +40,19 @@ type primitiveType =
   | TimestampType
 
 // ============================================================================
-// Core VQL Type System
+// Core VCL Type System
 // ============================================================================
 
-type rec vqlType =
+type rec vclType =
   | Primitive(primitiveType)
-  | ArrayType(vqlType)
+  | ArrayType(vclType)
   | ModalityType(modalityType)
   | HexadType(array<modalityType>) // hexad carrying specific modalities
   | QueryResultType(queryResultInfo) // result of a SELECT query
   | ProofType(proofKind, string) // Proof<kind, contract>
   | ProvedResultType(queryResultInfo, proofKind, string) // Sigma(result, proof)
-  | PiType(string, vqlType, vqlType) // Pi(x, domain, codomain)
-  | SigmaType(string, vqlType, vqlType) // Sigma(x, fst, snd)
+  | PiType(string, vclType, vclType) // Pi(x, domain, codomain)
+  | SigmaType(string, vclType, vclType) // Sigma(x, fst, snd)
   | UnitType
   | NeverType
 
@@ -198,10 +198,10 @@ let proofKindToString = (pk: proofKind): string => {
   }
 }
 
-let rec vqlTypeToString = (t: vqlType): string => {
+let rec vclTypeToString = (t: vclType): string => {
   switch t {
   | Primitive(pt) => primitiveTypeToString(pt)
-  | ArrayType(inner) => `Array<${vqlTypeToString(inner)}>`
+  | ArrayType(inner) => `Array<${vclTypeToString(inner)}>`
   | ModalityType(m) => modalityTypeToString(m)
   | HexadType(mods) => {
       let modStrs = mods->Belt.Array.map(modalityTypeToString)->Js.Array2.joinWith(", ")
@@ -217,9 +217,9 @@ let rec vqlTypeToString = (t: vqlType): string => {
       `Sigma(QueryResult<${modStrs}>, Proof<${proofKindToString(kind)}, ${contract}>)`
     }
   | PiType(x, domain, codomain) =>
-    `Pi(${x}: ${vqlTypeToString(domain)}) -> ${vqlTypeToString(codomain)}`
+    `Pi(${x}: ${vclTypeToString(domain)}) -> ${vclTypeToString(codomain)}`
   | SigmaType(x, fst, snd) =>
-    `Sigma(${x}: ${vqlTypeToString(fst)}, ${vqlTypeToString(snd)})`
+    `Sigma(${x}: ${vclTypeToString(fst)}, ${vclTypeToString(snd)})`
   | UnitType => "Unit"
   | NeverType => "Never"
   }
@@ -262,7 +262,7 @@ let eqModalityType = (a: modalityType, b: modalityType): bool => {
   }
 }
 
-let rec eqType = (a: vqlType, b: vqlType): bool => {
+let rec eqType = (a: vclType, b: vclType): bool => {
   switch (a, b) {
   | (Primitive(pa), Primitive(pb)) => eqPrimitiveType(pa, pb)
   | (ArrayType(ia), ArrayType(ib)) => eqType(ia, ib)

--- a/vql-bridge/vql_parser_port.js
+++ b/vql-bridge/vql_parser_port.js
@@ -1,54 +1,54 @@
 #!/usr/bin/env -S deno run --allow-read
 // SPDX-License-Identifier: MPL-2.0
-// VQL Parser Port — stdin/stdout JSON bridge for Elixir
+// VCL Parser Port — stdin/stdout JSON bridge for Elixir
 //
-// Reads JSON messages (one per line) from stdin, parses VQL queries
-// using the compiled ReScript VQLParser, and writes JSON results to stdout.
+// Reads JSON messages (one per line) from stdin, parses VCL queries
+// using the compiled ReScript VCLParser, and writes JSON results to stdout.
 //
 // Protocol: newline-delimited JSON
 //   Request:  {"id": 1, "action": "parse", "query": "SELECT ..."}
 //   Response: {"id": 1, "ok": {...ast...}} or {"id": 1, "error": "..."}
 
-// Import compiled ReScript VQL parser and type checker.
-// The compiled JS output will be at ../src/vql/*.res.mjs (ReScript compiler output).
-let VQLParser;
-let VQLTypeChecker;
-let VQLBidir;
+// Import compiled ReScript VCL parser and type checker.
+// The compiled JS output will be at ../src/vcl/*.res.mjs (ReScript compiler output).
+let VCLParser;
+let VCLTypeChecker;
+let VCLBidir;
 
 try {
-  VQLParser = await import("../src/vql/VQLParser.res.mjs");
+  VCLParser = await import("../src/vcl/VCLParser.res.mjs");
 } catch (_e) {
   try {
     // Legacy .bs.js suffix (older ReScript versions)
-    VQLParser = await import("../src/vql/VQLParser.bs.js");
+    VCLParser = await import("../src/vcl/VCLParser.bs.js");
   } catch (_e2) {
-    VQLParser = null;
+    VCLParser = null;
   }
 }
 
 try {
-  VQLTypeChecker = await import("../src/vql/VQLTypeChecker.res.mjs");
+  VCLTypeChecker = await import("../src/vcl/VCLTypeChecker.res.mjs");
 } catch (_e) {
   try {
-    VQLTypeChecker = await import("../src/vql/VQLTypeChecker.bs.js");
+    VCLTypeChecker = await import("../src/vcl/VCLTypeChecker.bs.js");
   } catch (_e2) {
-    VQLTypeChecker = null;
+    VCLTypeChecker = null;
   }
 }
 
 try {
-  VQLBidir = await import("../src/vql/VQLBidir.res.mjs");
+  VCLBidir = await import("../src/vcl/VCLBidir.res.mjs");
 } catch (_e) {
   try {
-    VQLBidir = await import("../src/vql/VQLBidir.bs.js");
+    VCLBidir = await import("../src/vcl/VCLBidir.bs.js");
   } catch (_e2) {
-    VQLBidir = null;
+    VCLBidir = null;
   }
 }
 
 /**
- * Minimal VQL parser fallback (when compiled ReScript is unavailable).
- * Produces AST compatible with VQLParser.res types.
+ * Minimal VCL parser fallback (when compiled ReScript is unavailable).
+ * Produces AST compatible with VCLParser.res types.
  */
 function fallbackParse(query) {
   const tokens = query.trim().split(/\s+/);
@@ -260,8 +260,8 @@ function fallbackParse(query) {
 }
 
 /**
- * Minimal VQL mutation parser fallback (INSERT / UPDATE / DELETE).
- * Produces AST compatible with VQLParser.res mutation types.
+ * Minimal VCL mutation parser fallback (INSERT / UPDATE / DELETE).
+ * Produces AST compatible with VCLParser.res mutation types.
  */
 function fallbackParseMutation(input) {
   const tokens = input.trim().split(/\s+/);
@@ -375,7 +375,7 @@ function fallbackParseMutation(input) {
 }
 
 /**
- * Parse a VQL statement (query or mutation) using fallback parser.
+ * Parse a VCL statement (query or mutation) using fallback parser.
  */
 function fallbackParseStatement(input) {
   const trimmed = input.trim();
@@ -389,26 +389,26 @@ function fallbackParseStatement(input) {
 }
 
 /**
- * Parse a VQL query using the ReScript parser or fallback.
+ * Parse a VCL query using the ReScript parser or fallback.
  */
 function parseQuery(query, action) {
-  if (VQLParser) {
+  if (VCLParser) {
     let result;
     switch (action) {
       case "parse_slipstream":
-        result = VQLParser.parseSlipstream(query);
+        result = VCLParser.parseSlipstream(query);
         break;
       case "parse_dependent":
-        result = VQLParser.parseDependentType(query);
+        result = VCLParser.parseDependentType(query);
         break;
       case "parse_mutation":
-        result = VQLParser.parseMutation(query);
+        result = VCLParser.parseMutation(query);
         break;
       case "parse_statement":
-        result = VQLParser.parseStatement(query);
+        result = VCLParser.parseStatement(query);
         break;
       default:
-        result = VQLParser.parse(query);
+        result = VCLParser.parse(query);
     }
     // ReScript Result type: { TAG: "Ok", _0: value } or { TAG: "Error", _0: error }
     if (result.TAG === "Ok") return { ok: result._0 };
@@ -427,36 +427,36 @@ function parseQuery(query, action) {
 }
 
 // ---------------------------------------------------------------------------
-// Type checking: invoke ReScript VQLBidir or extract obligations from AST
+// Type checking: invoke ReScript VCLBidir or extract obligations from AST
 // ---------------------------------------------------------------------------
 
 /**
- * Type-check a parsed VQL-DT AST.
+ * Type-check a parsed VCL-DT AST.
  *
- * If compiled ReScript is available, delegates to VQLBidir.synthesizeQuery
+ * If compiled ReScript is available, delegates to VCLBidir.synthesizeQuery
  * for full bidirectional type inference. Otherwise, extracts proof obligations
  * directly from the AST's proof clause — a sound but less precise fallback.
  *
- * @param {object} ast - Parsed VQL query AST
+ * @param {object} ast - Parsed VCL query AST
  * @returns {{ ok: object } | { error: string }} - Type info or error
  */
 function typecheckAST(ast) {
   // Try the full ReScript type checker first
-  if (VQLBidir) {
+  if (VCLBidir) {
     try {
-      const result = VQLBidir.synthesizeQuery(ast);
+      const result = VCLBidir.synthesizeQuery(ast);
       if (result.TAG === "Ok") {
         return { ok: result._0 };
       }
       return { error: result._0?.message || JSON.stringify(result._0) };
     } catch (e) {
-      // If VQLBidir crashes, fall through to the lightweight fallback
+      // If VCLBidir crashes, fall through to the lightweight fallback
     }
   }
 
-  if (VQLTypeChecker) {
+  if (VCLTypeChecker) {
     try {
-      const result = VQLTypeChecker.checkQuery(ast);
+      const result = VCLTypeChecker.checkQuery(ast);
       if (result.TAG === "Ok") {
         return { ok: result._0 };
       }
@@ -475,7 +475,7 @@ function typecheckAST(ast) {
 /**
  * Fallback type checking: extract proof obligations from an AST's proof clause.
  *
- * Returns a structure matching what VQLBidir.synthesizeQuery would produce:
+ * Returns a structure matching what VCLBidir.synthesizeQuery would produce:
  * { proof_obligations, composition_strategy, inferred_types }
  */
 function fallbackTypecheck(ast) {


### PR DESCRIPTION
## VCL rename — stage B (3/5): ReScript

Continues the staged `VQL → VCL` (VeriSim **Consonance** Language) rename. Stage `2/5` deliberately skipped ReScript; this completes it across all three independent ReScript projects (each has its own `rescript.json`, flat module namespace).

### ReScript source
| Project | Change |
|---|---|
| `src/vql/` → `src/vcl/` | `VQL*.res` → `VCL*.res` (parser, type-checker, bidir, subtyping, proof obligations, circuits, explain, context, types, errors) — module renames carried through all intra-project refs |
| `playground/` | `VqlKeywords.res` → `VclKeywords.res`; `/vql/execute` → `/vcl/execute`; "VQL Playground" → "VCL Playground" (rescript.json / package.json / deno.json / `public/` assets) |
| `connectors/clients/rescript/` | `VeriSimVql.res` → `VeriSimVcl.res`; `/api/v1/vql/{execute,explain}` → `/vcl/{…}`; `vqlResult`→`vclResult`, `VqlParseError`/`VqlExecutionError`→`Vcl*` |

The acronym **gloss** was corrected from "Query Language" → "Consonance Language" per `CLAUDE.md`. Incidental `query`/`Query` identifiers (e.g. `executeQuery`, `query:` fields) are **left as-is**, consistent with `QueryRouter` keeping its name.

### Functional couplings updated (so nothing breaks on rebuild/CI)
- **`vql-bridge/vql_parser_port.js`** — dynamic imports retargeted `../src/vql/VQL*.res.mjs` → `../src/vcl/VCL*.res.mjs`. The **filename is intentionally kept** so the Elixir `vcl_bridge.ex` spawn path (`vql-bridge/vql_parser_port.js`) stays valid; the dir rename belongs to the Elixir stage.
- **`.hypatia-ignore`** — renamed `.res` whitelist paths.
- **`.github/CODEOWNERS`** — `/src/vql/` → `/src/vcl/`.
- **contractiles `Must`/`Dust`** — directory assertions (`test -d src/vql`, mjs-tracking `target`) retargeted to `src/vcl` (the `test -d src/vql` assertion would otherwise start failing the moment the dir moved).

### Verification
There is **no ReScript toolchain in this environment or in CI**, so this was validated **statically**:
- zero residual `vql` (any case) in the three projects + bridge + the fixed configs;
- symmetric token diff (256 insertions / 256 deletions — pure rename);
- no dangling references to the old module names anywhere functional.

`tests/doc-consonance-gate.sh` stays **green** (it only flags the literal phrase "VeriSim Query Language" in docs).

### Deferred (other stages)
- **4/5 — Elixir**: `VQLBridge`/`VQLExecutor` module names, `bench/vql_*_bench.exs`, and the `vql-bridge/` dir rename (+ its spawn path).
- **5/5 — docs/specs**: `docs/*`, machine-readable a2ml, `.verisimdb/octads/*.json` provenance, `*.vql` examples.

### ⚠️ Pre-existing leftovers found (NOT ReScript — separate follow-up)
- **`ffi/zig/` GraphQL gateway** still calls the Rust core's old `/vql/execute` (`graphql.zig:108`, `router.zig:56`). Since the Rust endpoint became `/vcl/execute` in stage `1/5` with **no alias**, this Zig proxy is already broken upstream — a missed caller from the endpoint hard-rename.
- **`.clusterfuzzlite/build.sh`** names `fuzz_vql_parser`, but Cargo.toml renamed the target to `fuzz_vcl_parser` in `1/5`.

---
🤖 Draft. Part of the staged `#84` VCL rename.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9Voe3JceP66Bna9FT4jME)_