### PR TITLE
fix(vclt-gate): reject on levels[].status=="fail", not never-emitted "admitted"

### DIFF
--- a/elixir-orchestration/lib/verisim/query/vclt_gate.ex
+++ b/elixir-orchestration/lib/verisim/query/vclt_gate.ex
@@ -155,7 +155,7 @@ defmodule VeriSim.Query.VCLTGate do
       {:ok, %{"levels" => levels}} when is_list(levels) ->
         failed =
           levels
-          |> Enum.reject(fn l -> l["admitted"] == true end)
+          |> Enum.filter(fn l -> l["status"] == "fail" end)
           |> Enum.map(fn l ->
             "#{l["name"]} (L#{l["level"]}): #{l["reason"] || "rejected"}"
           end)

--- a/elixir-orchestration/test/verisim/query/vclt_gate_test.exs
+++ b/elixir-orchestration/test/verisim/query/vclt_gate_test.exs
@@ -54,7 +54,7 @@ defmodule VeriSim.Query.VCLTGateTest do
 
       File.write!(stub, """
       #!/bin/sh
-      echo '{"certified_level":-1,"levels":[{"level":4,"name":"InjectionProof","admitted":false,"reason":"SQL injection detected"}]}'
+      echo '{"certified_level":-1,"levels":[{"level":4,"name":"InjectionProof","status":"fail","reason":"SQL injection detected"}]}'
       exit 1
       """)
 


### PR DESCRIPTION
Fixes a cross-repo seam bug between the vcl-ut gate producer and this consumer that was invisible to both CIs.

`VCLTGate.extract_reasons` rejected levels where `l["admitted"] == true`, but the vcl-ut `vclt-gate` producer **never emits** an `admitted` key — it emits per-level `status` in `{"pass","fail"}`. So `Enum.reject` kept *every* level and the rejection-reasons list included passing levels.

- Consumer: `Enum.reject(admitted==true)` → `Enum.filter(status=="fail")`, so `failed` holds the genuinely-failing levels.
- Test: the stub fabricated an `"admitted"` key (which masked the drift); updated to the real `{"status":"fail"}` schema.

The matching producer-side `status` schema is in vcl-ut (`src/interface/parse/src/bin/vclt-gate.rs`). Local `mix test` couldn't run here (deps not fetched in the offline env); the logic change is a one-liner verified by standalone elixir execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
