### PR TITLE
License GitHub community-health workflows as MPL-2.0 (fix reuse lint)

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+# SPDX-License-Identifier: MPL-2.0
 name: Governance
 
 on:

--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+# SPDX-License-Identifier: MPL-2.0
 name: Hypatia Security Scan
 
 on:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,4 +1,5 @@
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+# SPDX-License-Identifier: MPL-2.0
 name: OSSF Scorecard
 
 on:


### PR DESCRIPTION
## What

Licenses the three standards-adopted **community-health workflow stubs** — `hypatia-scan.yml`, `governance.yml`, `scorecard.yml` — as **MPL-2.0** (with the standard two-line SPDX header), removing the bare `PMPL-1.0-or-later` identifier that was failing `reuse lint`.

## Why

`reuse lint` was failing, and the first instinct (add a `LICENSES/PMPL-1.0-or-later.txt`) doesn't work — it's a catch-22:

- **File absent:** `Missing licenses: PMPL-1.0-or-later`
- **File present:** `Bad licenses … not valid SPDX … do not start with 'LicenseRef-'`

`PMPL` (Palimpsest Meta-Public License) is a **custom** license, so REUSE only accepts it via a `LicenseRef-` prefix — a bare `PMPL-1.0-or-later` can't pass either way. Meanwhile `REUSE.toml` already aggregates `.github/**` and `**/*.yml` as **MPL-2.0**, so the inline PMPL header just layered an invalid second license on top.

## How

Per maintainer direction: these are **GitHub community-health files**, so license them as **MPL-2.0** (the estate's code/config license), keeping **MPL-2.0 + CC-BY-SA-4.0** as the repo's two licenses. PMPL is no longer used, so no PMPL text file is needed.

```diff
-# SPDX-License-Identifier: PMPL-1.0-or-later
+# SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
+# SPDX-License-Identifier: MPL-2.0
```

## Validation — ran `reuse lint` locally ✅

```
* Bad licenses: 0
* Missing licenses: 0
* Unused licenses: 0
* Used licenses: CC-BY-SA-4.0, MPL-2.0
* Files with copyright information: 775 / 775
* Files with license information: 775 / 775
Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
```

> [!NOTE]
> The other two failing checks on this PR — **Hypatia scan** and **governance staleness** — are unrelated: they come from stale `hyperpolymath/standards` reusable-workflow pins (the `actions/cache@d4373f26` pin was fixed to `1bd1e32a # v4.2.0` on standards@main) and need an estate-standardization re-sync in `standards`, which is outside these repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nyxs8RgqZa72PzrTu3L75