### PR TITLE
chore(licence): normalise to MPL-2.0 + CC-BY-SA-4.0 (canonical pair)

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
 # Support
 
 ## How to Get Help

--- a/.machine_readable/6a2/README.adoc
+++ b/.machine_readable/6a2/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # A2ML 6a2 Directory
 

--- a/.machine_readable/svc/k9/README.adoc
+++ b/.machine_readable/svc/k9/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = K9 Contractiles
 :toc: left
 :icons: font

--- a/AUDIT.adoc
+++ b/AUDIT.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = VeriSimDB Audit Index

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = VeriSimDB Changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to VeriSimDB
 
-<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
 <!-- Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk> -->
 
 Thank you for your interest in contributing to VeriSimDB. This document explains how to get started, our development workflow, and how to submit changes.
@@ -175,7 +175,7 @@ cargo fmt --check
 By contributing, you agree that your contributions will be licensed under the **MPL-2.0**. All source files must include:
 
 ```
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 ```
 
 ---

--- a/EXPLAINME.adoc
+++ b/EXPLAINME.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = EXPLAINME — VeriSimDB Orientation
 :toc:
 :toc-placement!:

--- a/KNOWN-ISSUES.adoc
+++ b/KNOWN-ISSUES.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = Known Issues and Honest Gaps

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-SPDX-License-Identifier: MPL-2.0
-
 Mozilla Public License Version 2.0
 ==================================
 
@@ -37,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
+    means a work that combines Covered Software with other material, in 
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -359,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/MAINTAINERS.adoc
+++ b/MAINTAINERS.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = Maintainers
 :toc: preamble
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VeriSimDB
 image:https://img.shields.io/badge/OpenSSF-Best_Practices-green?logo=openssourcesecurity[OpenSSF Best Practices,link="https://www.bestpractices.dev/en/projects/new?repo_url=https://github.com/hyperpolymath/verisimdb"]

--- a/connectors/README.adoc
+++ b/connectors/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 = VeriSimDB Connectors -- Federation Adapters & Client SDKs
 :toc: macro

--- a/connectors/clients/zig/README.adoc
+++ b/connectors/clients/zig/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 = VeriSimDB Zig Client SDK
 :author: Jonathan D.A. Jewell

--- a/connectors/test-infra/README.adoc
+++ b/connectors/test-infra/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 //
 // Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # VeriSimDB Documentation Index

--- a/docs/VCL-SPEC.adoc
+++ b/docs/VCL-SPEC.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = VeriSim Consonance Language (VCL) Specification

--- a/docs/adoption-strategy.adoc
+++ b/docs/adoption-strategy.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = VeriSimDB External Adoption Strategy
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 :toc: left

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
 <!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
 
 # TOPOLOGY.md — VeriSimDB

--- a/docs/backwards-compatibility.adoc
+++ b/docs/backwards-compatibility.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VCL Backwards Compatibility Strategy
 :toc:

--- a/docs/business/business-case.adoc
+++ b/docs/business/business-case.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB Business Case
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/marketing/feature-comparison.adoc
+++ b/docs/business/marketing/feature-comparison.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB Feature Comparison Matrix
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/marketing/one-pager.adoc
+++ b/docs/business/marketing/one-pager.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB — Product One-Pager
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/marketing/pitch-deck-outline.adoc
+++ b/docs/business/marketing/pitch-deck-outline.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB Pitch Deck — 12-Slide Structure
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/marketing/use-cases.adoc
+++ b/docs/business/marketing/use-cases.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB Use Cases — 7 Target Domains
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/pr/faq.adoc
+++ b/docs/business/pr/faq.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB — Frequently Asked Questions
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/pr/key-messages.adoc
+++ b/docs/business/pr/key-messages.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB -- Key Messages and Talking Points
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/pr/press-release.adoc
+++ b/docs/business/pr/press-release.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB Launch Press Release
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/strategy/adoption-roadmap.adoc
+++ b/docs/business/strategy/adoption-roadmap.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB -- Adoption Roadmap
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/strategy/economics-analysis.adoc
+++ b/docs/business/strategy/economics-analysis.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB -- Economics Analysis
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/strategy/functional-units.adoc
+++ b/docs/business/strategy/functional-units.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB -- Functional Units and Organisational Structure
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/business/strategy/go-to-market.adoc
+++ b/docs/business/strategy/go-to-market.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VeriSimDB -- Go-to-Market Strategy
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>

--- a/docs/cache-sharing-strategy.adoc
+++ b/docs/cache-sharing-strategy.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Cache Sharing Strategy: Local vs Federated
 :toc: left

--- a/docs/caching-strategy.adoc
+++ b/docs/caching-strategy.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VeriSimDB Caching Strategy
 :toc: left

--- a/docs/challenges-federated.adoc
+++ b/docs/challenges-federated.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Challenges: Federated Deployment Mode
 

--- a/docs/challenges-hybrid.adoc
+++ b/docs/challenges-hybrid.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Challenges: Hybrid Deployment Mode
 

--- a/docs/challenges-standalone.adoc
+++ b/docs/challenges-standalone.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Challenges: Standalone Deployment Mode
 

--- a/docs/consultation-dependent-types-zkp.adoc
+++ b/docs/consultation-dependent-types-zkp.adoc
@@ -6,7 +6,7 @@
 :sectnums:
 :source-highlighter: rouge
 
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 [abstract]
 == Abstract

--- a/docs/consultation-normalization-strategy.adoc
+++ b/docs/consultation-normalization-strategy.adoc
@@ -6,7 +6,7 @@
 :sectnums:
 :source-highlighter: rouge
 
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 [abstract]
 == Abstract

--- a/docs/decisions/kraft-comparison.adoc
+++ b/docs/decisions/kraft-comparison.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = KRaft vs VeriSimDB Comparison
 

--- a/docs/decisions/rust-spark-stance.adoc
+++ b/docs/decisions/rust-spark-stance.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = Rust/SPARK Stance — verisimdb
 :toc: macro
 :toclevels: 2

--- a/docs/deployment-modes.adoc
+++ b/docs/deployment-modes.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VeriSimDB Deployment Modes
 

--- a/docs/deployment/deployment.adoc
+++ b/docs/deployment/deployment.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = VeriSimDB Production Deployment Guide
 :toc:
 :toc-placement!:

--- a/docs/design/DESIGN-2026-02-27-level-data-model.md
+++ b/docs/design/DESIGN-2026-02-27-level-data-model.md
@@ -1,5 +1,5 @@
 # Design Document: IDApTIK Level Architect — Canonical Level Data Model
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC-BY-SA-4.0
 
 **Date:** 2026-02-27
 **Author:** Jonathan D.A. Jewell (hyperpolymath)

--- a/docs/design/DESIGN-2026-02-27-strategic-improvements.adoc
+++ b/docs/design/DESIGN-2026-02-27-strategic-improvements.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Design Document: VerisimDB Strategic Improvements
 // Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 // Date: 2026-02-27

--- a/docs/design/DESIGN-2026-02-27-vcl-dt-assessment.adoc
+++ b/docs/design/DESIGN-2026-02-27-vcl-dt-assessment.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 = VCL-DT (Dependent Type Path) Wiring Assessment
 :author: Jonathan D.A. Jewell (hyperpolymath)

--- a/docs/drift-handling.adoc
+++ b/docs/drift-handling.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Drift Handling in VeriSimDB
 :toc:

--- a/docs/error-handling-strategy.adoc
+++ b/docs/error-handling-strategy.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VCL Error Handling Strategy
 :toc: left

--- a/docs/federation-readiness.adoc
+++ b/docs/federation-readiness.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = Federation Readiness Assessment

--- a/docs/getting-started.adoc
+++ b/docs/getting-started.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = VeriSimDB Getting Started Guide
 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 :toc: left

--- a/docs/minikanren-integration-v3.adoc
+++ b/docs/minikanren-integration-v3.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = miniKanren Integration (v3 Roadmap)
 :toc:

--- a/docs/normalization-cascade.adoc
+++ b/docs/normalization-cascade.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Normalization Cascade Architecture
 :toc: left

--- a/docs/panll-module-audit.adoc
+++ b/docs/panll-module-audit.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // PanLL Module Audit: Systematic Evaluation of hyperpolymath Repos
 // Author: Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 // Date: 2026-02-28

--- a/docs/papers/verisimdb-federated-consistency.adoc
+++ b/docs/papers/verisimdb-federated-consistency.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = VeriSimDB: Cross-Modal Drift Detection and Self-Normalisation in Heterogeneous Database Federations

--- a/docs/papers/verisimdb-idaptik-case-study.adoc
+++ b/docs/papers/verisimdb-idaptik-case-study.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = Applying Multimodal Database Technology to Game Level Architecture: A VeriSimDB Case Study

--- a/docs/proof-debt.md
+++ b/docs/proof-debt.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-License-Identifier: CC-BY-SA-4.0 -->
 # Proof Debt — Trusted Base of the VeriSimDB Formal Development
 
 This document is the authoritative catalogue of **soundness-relevant escape

--- a/docs/query-optimization-overview.adoc
+++ b/docs/query-optimization-overview.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VCL Query Optimization: Complete Guide
 :toc: left

--- a/docs/rescript-registry-types.adoc
+++ b/docs/rescript-registry-types.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VeriSimDB: ReScript Registry Type Definitions
 

--- a/docs/reversibility-design.adoc
+++ b/docs/reversibility-design.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Reversibility in VeriSimDB: Design Analysis
 :toc: left

--- a/docs/reviews/2026-06-11-deep-review-and-july-1-plan.adoc
+++ b/docs/reviews/2026-06-11-deep-review-and-july-1-plan.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = VeriSimDB Deep Review & July-1 Plan (2026-06-11)

--- a/docs/rsr-compliance.adoc
+++ b/docs/rsr-compliance.adoc
@@ -209,7 +209,7 @@ This template is part of:
 
 == License
 
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 
 == Links
 

--- a/docs/safety-and-fault-tolerance.adoc
+++ b/docs/safety-and-fault-tolerance.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Safety and Fault Tolerance
 :toc: left

--- a/docs/safety-theory-applied.adoc
+++ b/docs/safety-theory-applied.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Safety Theory Applied to VeriSimDB
 :toc: left

--- a/docs/snapshotting-and-truncation-logic.adoc
+++ b/docs/snapshotting-and-truncation-logic.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VeriSimDB: Snapshotting & Truncation Logic
 

--- a/docs/status/implementation-plan.adoc
+++ b/docs/status/implementation-plan.adoc
@@ -2,7 +2,7 @@
 :toc:
 :toc-placement!:
 
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 [.lead]
 **Bringing VeriSimDB from 10% to 70% completion**

--- a/docs/tech-debt-2026-05-26.md
+++ b/docs/tech-debt-2026-05-26.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
 -->
 

--- a/docs/technical-specification-kraft-metadata-log.adoc
+++ b/docs/technical-specification-kraft-metadata-log.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = Technical Specification: The KRaft Metadata Log
 

--- a/docs/vcl-architecture.adoc
+++ b/docs/vcl-architecture.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VCL Architecture: Dual-Path Query Router
 :toc: left

--- a/docs/vcl-examples.adoc
+++ b/docs/vcl-examples.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VeriSim Consonance Language (VCL) Examples
 :toc: left

--- a/docs/vcl-formal-semantics.adoc
+++ b/docs/vcl-formal-semantics.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VCL Formal Semantics
 :toc: left

--- a/docs/vcl-type-system.adoc
+++ b/docs/vcl-type-system.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = VCL Type System Specification
 :toc: left

--- a/docs/vcl-vs-sql.adoc
+++ b/docs/vcl-vs-sql.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = VCL vs SQL: A Comparative Guide

--- a/docs/vcl-vs-vcl-dt.adoc
+++ b/docs/vcl-vs-vcl-dt.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 = VCL Execution Modes & Safety Architecture

--- a/docs/zkp-and-sanctify-integration.adoc
+++ b/docs/zkp-and-sanctify-integration.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 
 = ZK-Historiography: Proven & Sactify-PHP Integration
 

--- a/elixir-orchestration/coveralls-coverage-targets.md
+++ b/elixir-orchestration/coveralls-coverage-targets.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
 -->
 

--- a/ffi/zig/README.adoc
+++ b/ffi/zig/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath)
 
 = VeriSimDB Zig — Unified API Gateway + FFI

--- a/formal/CROSS-REPO-MAP.adoc
+++ b/formal/CROSS-REPO-MAP.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 = VeriSimDB formal/ ↔ Echo-Types cross-repo mapping
 :toc:

--- a/spec/README.adoc
+++ b/spec/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // @taxonomy: spec/index
 = verisimdb — Specification Directory
 :toc:

--- a/spec/system-specs.md
+++ b/spec/system-specs.md
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MPL-2.0
+# SPDX-License-Identifier: CC-BY-SA-4.0
 # Copyright (c) 2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
 
 # VeriSimDB System Specifications

--- a/verification/README.adoc
+++ b/verification/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // @taxonomy: verification/index
 = verisimdb — Verification Directory
 :toc:


### PR DESCRIPTION
Estate licence normalisation. LICENSES/={MPL-2.0,CC-BY-SA-4.0}; root LICENSE=verbatim MPL-2.0 (GitHub display); code->MPL-2.0, docs(.md/.adoc)->CC-BY-SA-4.0; vendored untouched. Residual mentions (mostly legitimate anti-AGPL rules): 15. Manual-review licence PR.